### PR TITLE
Configure QuakeAlert defaults and disable channel management

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
     compileSdkVersion 35
 
     defaultConfig {
-        applicationId "io.heckel.ntfy"
+        applicationId "id.my.bananapixel.quakealert"
         minSdkVersion 21
         targetSdkVersion 35
 

--- a/app/src/debug/res/values/values.xml
+++ b/app/src/debug/res/values/values.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">ntfy (debug)</string>
+    <string name="app_name" translatable="false">QuakeAlert (debug)</string>
 </resources>

--- a/app/src/main/java/io/heckel/ntfy/app/Application.kt
+++ b/app/src/main/java/io/heckel/ntfy/app/Application.kt
@@ -1,15 +1,76 @@
 package io.heckel.ntfy.app
 
 import android.app.Application
+import io.heckel.ntfy.R
 import io.heckel.ntfy.db.Repository
+import io.heckel.ntfy.db.Subscription
+import io.heckel.ntfy.db.User
+import io.heckel.ntfy.firebase.FirebaseMessenger
 import io.heckel.ntfy.util.Log
+import io.heckel.ntfy.util.randomSubscriptionId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 class Application : Application() {
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     val repository by lazy {
         val repository = Repository.getInstance(applicationContext)
         if (repository.getRecordLogs()) {
             Log.setRecord(true)
         }
         repository
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        initializeDefaults()
+    }
+
+    private fun initializeDefaults() {
+        val baseUrl = getString(R.string.app_base_url)
+        applicationScope.launch {
+            val repo = repository
+            ensureDefaultUser(repo, baseUrl)
+            ensureDefaultSubscription(repo, baseUrl)
+        }
+    }
+
+    private suspend fun ensureDefaultUser(repository: Repository, baseUrl: String) {
+        val existingUser = repository.getUser(baseUrl)
+        if (existingUser == null) {
+            repository.addUser(User(baseUrl, DEFAULT_USERNAME, DEFAULT_PASSWORD))
+        }
+    }
+
+    private suspend fun ensureDefaultSubscription(repository: Repository, baseUrl: String) {
+        val existingSubscription = repository.getSubscription(baseUrl, DEFAULT_CHANNEL_TOPIC)
+        if (existingSubscription == null) {
+            val subscription = Subscription(
+                id = randomSubscriptionId(),
+                baseUrl = baseUrl,
+                topic = DEFAULT_CHANNEL_TOPIC,
+                instant = true,
+                mutedUntil = 0,
+                minPriority = Repository.MIN_PRIORITY_USE_GLOBAL,
+                autoDelete = Repository.AUTO_DELETE_USE_GLOBAL,
+                insistent = Repository.INSISTENT_MAX_PRIORITY_USE_GLOBAL,
+                lastNotificationId = null,
+                icon = null,
+                upAppId = null,
+                upConnectorToken = null,
+                displayName = null,
+                dedicatedChannels = false
+            ).copy(lastActive = System.currentTimeMillis() / 1000)
+            repository.addSubscription(subscription)
+            FirebaseMessenger().subscribe(DEFAULT_CHANNEL_TOPIC)
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_CHANNEL_TOPIC = "peringatan_gempa_darurat_xyz"
+        private const val DEFAULT_USERNAME = "vito100"
+        private const val DEFAULT_PASSWORD = "Archerc80new"
     }
 }

--- a/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
@@ -381,10 +381,6 @@ class DetailActivity : AppCompatActivity(), ActionMode.Callback, NotificationFra
                 onSettingsClick()
                 true
             }
-            R.id.detail_menu_unsubscribe -> {
-                onDeleteClick()
-                true
-            }
             else -> super.onOptionsItemSelected(item)
         }
     }
@@ -595,33 +591,6 @@ class DetailActivity : AppCompatActivity(), ActionMode.Callback, NotificationFra
         intent.putExtra(EXTRA_SUBSCRIPTION_TOPIC, subscriptionTopic)
         intent.putExtra(EXTRA_SUBSCRIPTION_DISPLAY_NAME, subscriptionDisplayName)
         startActivity(intent)
-    }
-
-    private fun onDeleteClick() {
-        Log.d(TAG, "Deleting subscription ${topicShortUrl(subscriptionBaseUrl, subscriptionTopic)}")
-
-        val builder = AlertDialog.Builder(this)
-        val dialog = builder
-            .setMessage(R.string.detail_delete_dialog_message)
-            .setPositiveButton(R.string.detail_delete_dialog_permanently_delete) { _, _ ->
-                Log.d(TAG, "Deleting subscription with subscription ID $subscriptionId (topic: $subscriptionTopic)")
-                GlobalScope.launch(Dispatchers.IO) {
-                    repository.removeAllNotifications(subscriptionId)
-                    repository.removeSubscription(subscriptionId)
-                    if (subscriptionBaseUrl == appBaseUrl) {
-                        messenger.unsubscribe(subscriptionTopic)
-                    }
-                }
-                finish()
-            }
-            .setNegativeButton(R.string.detail_delete_dialog_cancel) { _, _ -> /* Do nothing */ }
-            .create()
-        dialog.setOnShowListener {
-            dialog
-                .getButton(AlertDialog.BUTTON_POSITIVE)
-                .dangerButton(this)
-        }
-        dialog.show()
     }
 
     private fun onNotificationClick(notification: Notification) {

--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -91,9 +91,10 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
 
         // Floating action button ("+")
         fab = findViewById(R.id.fab)
-        fab.setOnClickListener {
-            onSubscribeButtonClick()
-        }
+        fab.hide()
+        fab.isEnabled = false
+        fab.isClickable = false
+        fab.visibility = View.GONE
 
         // Swipe to refresh
         mainListContainer = findViewById(R.id.main_subscriptions_list_container)
@@ -549,9 +550,7 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
     }
 
     private fun onSubscriptionItemLongClick(subscription: Subscription) {
-        if (actionMode == null) {
-            beginActionMode(subscription)
-        }
+        // Channel deletion is disabled; ignore long presses on subscriptions.
     }
 
     private fun refreshAllSubscriptions() {

--- a/app/src/main/res/menu/menu_detail_action_bar.xml
+++ b/app/src/main/res/menu/menu_detail_action_bar.xml
@@ -13,5 +13,4 @@
     <item android:id="@+id/detail_menu_copy_url" android:title="@string/detail_menu_copy_url"/>
     <item android:id="@+id/detail_menu_clear" android:title="@string/detail_menu_clear"/>
     <item android:id="@+id/detail_menu_test" android:title="@string/detail_menu_test"/>
-    <item android:id="@+id/detail_menu_unsubscribe" android:title="@string/detail_menu_unsubscribe"/>
 </menu>


### PR DESCRIPTION
## Summary
- update the Android application ID and debug app label to QuakeAlert
- seed the default emergency channel and credentials at application start
- remove UI affordances for adding or removing channels

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa939a79c832d92ed1e5272225252