### PR TITLE
Fix tools namespace in quake history layout

### DIFF
--- a/app/src/main/res/layout/item_quake_history.xml
+++ b/app/src/main/res/layout/item_quake_history.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="12dp"


### PR DESCRIPTION
## Summary
- declare the tools namespace on the quake history layout so tools-only attributes compile

## Testing
- `./gradlew assemblePlayDebug` *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb81cd074832db2deddc95f9197ff