### PR TITLE
Add Material text appearance aliases

### DIFF
--- a/app/src/main/res/values/material_text_appearances.xml
+++ b/app/src/main/res/values/material_text_appearances.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Provide Material3-inspired text appearance aliases for the current Material Components dependency -->
+    <style name="TextAppearance.MaterialComponents.LabelSmall" parent="@style/TextAppearance.MaterialComponents.Caption" />
+    <style name="TextAppearance.MaterialComponents.LabelLarge" parent="@style/TextAppearance.MaterialComponents.Subtitle2" />
+    <style name="TextAppearance.MaterialComponents.TitleMedium" parent="@style/TextAppearance.MaterialComponents.Subtitle1" />
+    <style name="TextAppearance.MaterialComponents.HeadlineSmall" parent="@style/TextAppearance.MaterialComponents.Headline6" />
+    <style name="TextAppearance.MaterialComponents.BodyLarge" parent="@style/TextAppearance.MaterialComponents.Body1" />
+    <style name="TextAppearance.MaterialComponents.BodyMedium" parent="@style/TextAppearance.MaterialComponents.Body2" />
+    <style name="TextAppearance.MaterialComponents.BodySmall" parent="@style/TextAppearance.MaterialComponents.Caption" />
+</resources>


### PR DESCRIPTION
## Summary
- add aliases for Material text appearances expected by new layouts so they resolve with the existing Material Components dependency

## Testing
- ./gradlew :app:processPlayDebugResources *(fails: Android SDK is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbb6b6590832dbd6c27f869ad6803