### PR TITLE
Add ViewPager2 dependency to fix crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,6 +108,9 @@ dependencies {
     // RecyclerView
     implementation "androidx.recyclerview:recyclerview:1.3.0"
 
+    // ViewPager2 for swipeable pages
+    implementation "androidx.viewpager2:viewpager2:1.1.0"
+
     // Swipe down to refresh
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 


### PR DESCRIPTION
## Summary
- add the AndroidX ViewPager2 dependency so the new pager layout inflates correctly

## Testing
- `./gradlew assembleFdroidDebug`


------
https://chatgpt.com/codex/tasks/task_e_68cfbd304974832dae7b7c6e75b3b56b