### PR TITLE
Add tab navigation with quake history screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,7 @@ dependencies {
 
     // RecyclerView
     implementation "androidx.recyclerview:recyclerview:1.3.0"
+    implementation "androidx.viewpager2:viewpager2:1.1.0"
 
     // Swipe down to refresh
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'

--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -22,15 +22,19 @@ import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.viewModels
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
+import androidx.viewpager2.widget.ViewPager2
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.work.*
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayoutMediator
 import io.heckel.ntfy.BuildConfig
 import io.heckel.ntfy.R
 import io.heckel.ntfy.app.Application
@@ -49,6 +53,7 @@ import io.heckel.ntfy.work.PollWorker
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
@@ -67,6 +72,25 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
     private lateinit var mainListContainer: SwipeRefreshLayout
     private lateinit var adapter: MainAdapter
     private lateinit var fab: FloatingActionButton
+    private lateinit var noEntries: View
+    private lateinit var tabLayout: TabLayout
+    private lateinit var viewPager: ViewPager2
+    private lateinit var pagerAdapter: MainPagerAdapter
+    private lateinit var historyAdapter: QuakeHistoryAdapter
+    private lateinit var historyList: RecyclerView
+    private lateinit var historyRefresh: SwipeRefreshLayout
+    private lateinit var historyEmpty: View
+    private lateinit var historyError: TextView
+    private lateinit var historyProgress: View
+
+    private var alertsPageBound = false
+    private var historyPageBound = false
+    private var historyLoaded = false
+    private var historyLoading = false
+    private var alertsPageView: View? = null
+    private var historyPageView: View? = null
+    private var latestSubscriptions: List<Subscription> = emptyList()
+    private val quakeHistoryService = QuakeHistoryService()
 
     // Other stuff
     private var actionMode: ActionMode? = null
@@ -86,8 +110,38 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         dispatcher = NotificationDispatcher(this, repository)
         appBaseUrl = getString(R.string.app_base_url)
 
-        // Action bar
-        title = getString(R.string.main_action_bar_title)
+        tabLayout = findViewById(R.id.main_tab_layout)
+        viewPager = findViewById(R.id.main_view_pager)
+        pagerAdapter = MainPagerAdapter(this)
+        viewPager.adapter = pagerAdapter
+        viewPager.offscreenPageLimit = 1
+
+        historyAdapter = QuakeHistoryAdapter()
+
+        TabLayoutMediator(tabLayout, viewPager) { tab, position ->
+            when (position) {
+                0 -> {
+                    tab.text = getString(R.string.main_tab_alerts)
+                    tab.icon = AppCompatResources.getDrawable(this, R.drawable.ic_tab_quake_alerts)
+                }
+                else -> {
+                    tab.text = getString(R.string.main_tab_history)
+                    tab.icon = AppCompatResources.getDrawable(this, R.drawable.ic_tab_quake_history)
+                }
+            }
+        }.attach()
+
+        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                updateToolbarTitle(position)
+                if (position == 1) {
+                    maybeLoadHistory()
+                }
+            }
+        })
+
+        updateToolbarTitle(viewPager.currentItem)
 
         // Floating action button ("+")
         fab = findViewById(R.id.fab)
@@ -96,31 +150,17 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         fab.isClickable = false
         fab.visibility = View.GONE
 
-        // Swipe to refresh
-        mainListContainer = findViewById(R.id.main_subscriptions_list_container)
-        mainListContainer.setOnRefreshListener { refreshAllSubscriptions() }
-        mainListContainer.setColorSchemeResources(Colors.refreshProgressIndicator)
-
-        // Update main list based on viewModel (& its datasource/livedata)
-        val noEntries: View = findViewById(R.id.main_no_subscriptions)
         val onSubscriptionClick = { s: Subscription -> onSubscriptionItemClick(s) }
         val onSubscriptionLongClick = { s: Subscription -> onSubscriptionItemLongClick(s) }
 
-        mainList = findViewById(R.id.main_subscriptions_list)
         adapter = MainAdapter(repository, onSubscriptionClick, onSubscriptionLongClick)
-        mainList.adapter = adapter
 
         viewModel.list().observe(this) {
             it?.let { subscriptions ->
+                latestSubscriptions = subscriptions
                 // Update main list
                 adapter.submitList(subscriptions as MutableList<Subscription>)
-                if (it.isEmpty()) {
-                    mainListContainer.visibility = View.GONE
-                    noEntries.visibility = View.VISIBLE
-                } else {
-                    mainListContainer.visibility = View.VISIBLE
-                    noEntries.visibility = View.GONE
-                }
+                updateSubscriptionVisibility(subscriptions)
 
                 // Add scrub terms to log (in case it gets exported)
                 subscriptions.forEach { s ->
@@ -159,75 +199,6 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
             SubscriberServiceManager.refresh(this)
         }
 
-        // Battery banner
-        val batteryBanner = findViewById<View>(R.id.main_banner_battery) // Banner visibility is toggled in onResume()
-        val dontAskAgainButton = findViewById<Button>(R.id.main_banner_battery_dontaskagain)
-        val askLaterButton = findViewById<Button>(R.id.main_banner_battery_ask_later)
-        val fixNowButton = findViewById<Button>(R.id.main_banner_battery_fix_now)
-        dontAskAgainButton.setOnClickListener {
-            batteryBanner.visibility = View.GONE
-            repository.setBatteryOptimizationsRemindTime(Repository.BATTERY_OPTIMIZATIONS_REMIND_TIME_NEVER)
-        }
-        askLaterButton.setOnClickListener {
-            batteryBanner.visibility = View.GONE
-            repository.setBatteryOptimizationsRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
-        }
-        fixNowButton.setOnClickListener {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
-                startActivity(intent)
-            }
-        }
-
-        // WebSocket banner
-        val wsBanner = findViewById<View>(R.id.main_banner_websocket) // Banner visibility is toggled in onResume()
-        val wsText = findViewById<TextView>(R.id.main_banner_websocket_text)
-        val wsDismissButton = findViewById<Button>(R.id.main_banner_websocket_dontaskagain)
-        val wsRemindButton = findViewById<Button>(R.id.main_banner_websocket_remind_later)
-        val wsEnableButton = findViewById<Button>(R.id.main_banner_websocket_enable)
-        wsText.movementMethod = LinkMovementMethod.getInstance() // Make links clickable
-        wsDismissButton.setOnClickListener {
-            wsBanner.visibility = View.GONE
-            repository.setWebSocketRemindTime(Repository.WEBSOCKET_REMIND_TIME_NEVER)
-        }
-        wsRemindButton.setOnClickListener {
-            wsBanner.visibility = View.GONE
-            repository.setWebSocketRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
-        }
-        wsEnableButton.setOnClickListener {
-            repository.setConnectionProtocol(Repository.CONNECTION_PROTOCOL_WS)
-            SubscriberServiceManager(this).restart()
-            wsBanner.visibility = View.GONE
-
-            // Maybe show WebSocketReconnectBanner
-            viewModel.list().observe(this) {
-                it?.let { subscriptions ->
-                    showHideWebSocketReconnectBanner(subscriptions)
-                }
-            }
-        }
-
-        // WebSocket Reconnect banner
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val wsReconnectBanner = findViewById<View>(R.id.main_banner_websocket_reconnect)
-            val wsReconnectText = findViewById<TextView>(R.id.main_banner_websocket_reconnect_text)
-            val wsReconnectDismissButton = findViewById<Button>(R.id.main_banner_websocket_reconnect_dontaskagain)
-            val wsReconnectRemindButton = findViewById<Button>(R.id.main_banner_websocket_reconnect_remind_later)
-            val wsReconnectEnableButton = findViewById<Button>(R.id.main_banner_websocket_reconnect_enable)
-            wsReconnectText.movementMethod = LinkMovementMethod.getInstance() // Make links clickable
-            wsReconnectDismissButton.setOnClickListener {
-                wsReconnectBanner.visibility = View.GONE
-                repository.setWebSocketReconnectRemindTime(Repository.WEBSOCKET_RECONNECT_REMIND_TIME_NEVER)
-            }
-            wsReconnectRemindButton.setOnClickListener {
-                wsReconnectBanner.visibility = View.GONE
-                repository.setWebSocketReconnectRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
-            }
-            wsReconnectEnableButton.setOnClickListener {
-                startActivity(Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
-            }
-        }
-
         // Create notification channels right away, so we can configure them immediately after installing the app
         dispatcher?.init()
 
@@ -244,6 +215,211 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
 
         // Permissions
         maybeRequestNotificationPermission()
+    }
+
+    private fun updateToolbarTitle(position: Int) {
+        title = if (position == 1) {
+            getString(R.string.quake_history_title)
+        } else {
+            getString(R.string.main_action_bar_title)
+        }
+    }
+
+    fun bindAlertsPage(view: View) {
+        if (alertsPageBound) {
+            return
+        }
+        alertsPageBound = true
+        alertsPageView = view
+
+        mainListContainer = view.findViewById(R.id.main_subscriptions_list_container)
+        mainListContainer.setOnRefreshListener { refreshAllSubscriptions() }
+        mainListContainer.setColorSchemeResources(Colors.refreshProgressIndicator)
+
+        mainList = view.findViewById(R.id.main_subscriptions_list)
+        mainList.adapter = adapter
+
+        noEntries = view.findViewById(R.id.main_no_subscriptions)
+
+        setupBatteryBanner(view)
+        setupWebSocketBanner(view)
+        setupWebSocketReconnectBanner(view)
+
+        updateSubscriptionVisibility(latestSubscriptions)
+        showHideBatteryBanner(latestSubscriptions)
+        showHideWebSocketBanner(latestSubscriptions)
+        showHideWebSocketReconnectBanner(latestSubscriptions)
+    }
+
+    fun bindHistoryPage(view: View) {
+        if (historyPageBound) {
+            return
+        }
+        historyPageBound = true
+        historyPageView = view
+
+        historyRefresh = view.findViewById(R.id.quake_history_refresh)
+        historyRefresh.setOnRefreshListener { maybeLoadHistory(force = true) }
+        historyRefresh.setColorSchemeResources(Colors.refreshProgressIndicator)
+
+        historyList = view.findViewById(R.id.quake_history_list)
+        historyList.adapter = historyAdapter
+
+        historyEmpty = view.findViewById(R.id.quake_history_empty)
+        historyError = view.findViewById(R.id.quake_history_error)
+        historyProgress = view.findViewById(R.id.quake_history_progress)
+
+        if (viewPager.currentItem == 1) {
+            maybeLoadHistory()
+        }
+    }
+
+    private fun updateSubscriptionVisibility(subscriptions: List<Subscription>) {
+        if (!this::mainListContainer.isInitialized || !this::noEntries.isInitialized) {
+            return
+        }
+        if (subscriptions.isEmpty()) {
+            mainListContainer.visibility = View.GONE
+            noEntries.visibility = View.VISIBLE
+        } else {
+            mainListContainer.visibility = View.VISIBLE
+            noEntries.visibility = View.GONE
+        }
+    }
+
+    private fun setupBatteryBanner(view: View) {
+        val batteryBanner = view.findViewById<View>(R.id.main_banner_battery)
+        val dontAskAgainButton = view.findViewById<Button>(R.id.main_banner_battery_dontaskagain)
+        val askLaterButton = view.findViewById<Button>(R.id.main_banner_battery_ask_later)
+        val fixNowButton = view.findViewById<Button>(R.id.main_banner_battery_fix_now)
+        dontAskAgainButton.setOnClickListener {
+            batteryBanner.visibility = View.GONE
+            repository.setBatteryOptimizationsRemindTime(Repository.BATTERY_OPTIMIZATIONS_REMIND_TIME_NEVER)
+        }
+        askLaterButton.setOnClickListener {
+            batteryBanner.visibility = View.GONE
+            repository.setBatteryOptimizationsRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
+        }
+        fixNowButton.setOnClickListener {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                startActivity(intent)
+            }
+        }
+    }
+
+    private fun setupWebSocketBanner(view: View) {
+        val wsBanner = view.findViewById<View>(R.id.main_banner_websocket)
+        val wsText = view.findViewById<TextView>(R.id.main_banner_websocket_text)
+        val wsDismissButton = view.findViewById<Button>(R.id.main_banner_websocket_dontaskagain)
+        val wsRemindButton = view.findViewById<Button>(R.id.main_banner_websocket_remind_later)
+        val wsEnableButton = view.findViewById<Button>(R.id.main_banner_websocket_enable)
+        wsText.movementMethod = LinkMovementMethod.getInstance()
+        wsDismissButton.setOnClickListener {
+            wsBanner.visibility = View.GONE
+            repository.setWebSocketRemindTime(Repository.WEBSOCKET_REMIND_TIME_NEVER)
+        }
+        wsRemindButton.setOnClickListener {
+            wsBanner.visibility = View.GONE
+            repository.setWebSocketRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
+        }
+        wsEnableButton.setOnClickListener {
+            repository.setConnectionProtocol(Repository.CONNECTION_PROTOCOL_WS)
+            SubscriberServiceManager(this).restart()
+            wsBanner.visibility = View.GONE
+
+            viewModel.list().observe(this) {
+                it?.let { subscriptions ->
+                    showHideWebSocketReconnectBanner(subscriptions)
+                }
+            }
+        }
+    }
+
+    private fun setupWebSocketReconnectBanner(view: View) {
+        val wsReconnectBanner = view.findViewById<View>(R.id.main_banner_websocket_reconnect)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val wsReconnectText = view.findViewById<TextView>(R.id.main_banner_websocket_reconnect_text)
+            val wsReconnectDismissButton = view.findViewById<Button>(R.id.main_banner_websocket_reconnect_dontaskagain)
+            val wsReconnectRemindButton = view.findViewById<Button>(R.id.main_banner_websocket_reconnect_remind_later)
+            val wsReconnectEnableButton = view.findViewById<Button>(R.id.main_banner_websocket_reconnect_enable)
+            wsReconnectText.movementMethod = LinkMovementMethod.getInstance()
+            wsReconnectDismissButton.setOnClickListener {
+                wsReconnectBanner.visibility = View.GONE
+                repository.setWebSocketReconnectRemindTime(Repository.WEBSOCKET_RECONNECT_REMIND_TIME_NEVER)
+            }
+            wsReconnectRemindButton.setOnClickListener {
+                wsReconnectBanner.visibility = View.GONE
+                repository.setWebSocketReconnectRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
+            }
+            wsReconnectEnableButton.setOnClickListener {
+                startActivity(Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+            }
+        } else {
+            wsReconnectBanner.visibility = View.GONE
+        }
+    }
+
+    private fun maybeLoadHistory(force: Boolean = false) {
+        if (!historyPageBound) {
+            return
+        }
+        if (historyLoading) {
+            return
+        }
+        if (!force && historyLoaded) {
+            return
+        }
+        startLoadingHistory()
+    }
+
+    private fun startLoadingHistory() {
+        if (!historyPageBound ||
+            !this::historyRefresh.isInitialized ||
+            !this::historyError.isInitialized ||
+            !this::historyProgress.isInitialized ||
+            !this::historyEmpty.isInitialized
+        ) {
+            return
+        }
+
+        historyLoading = true
+        historyError.visibility = View.GONE
+        historyEmpty.visibility = View.GONE
+        if (!historyRefresh.isRefreshing) {
+            historyProgress.visibility = View.VISIBLE
+        }
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val reports = try {
+                quakeHistoryService.fetchReports()
+            } catch (exception: Exception) {
+                Log.e(TAG, "Error loading quake history", exception)
+                null
+            }
+            withContext(Dispatchers.Main) {
+                historyLoading = false
+                historyRefresh.isRefreshing = false
+                historyProgress.visibility = View.GONE
+                if (reports != null) {
+                    historyLoaded = true
+                    historyAdapter.submitList(reports)
+                    if (reports.isEmpty()) {
+                        historyEmpty.visibility = View.VISIBLE
+                    } else {
+                        historyEmpty.visibility = View.GONE
+                    }
+                    historyError.visibility = View.GONE
+                } else {
+                    historyLoaded = false
+                    if (historyAdapter.itemCount == 0) {
+                        historyEmpty.visibility = View.GONE
+                    }
+                    historyError.visibility = View.VISIBLE
+                    Toast.makeText(this@MainActivity, getString(R.string.quake_history_error), Toast.LENGTH_LONG).show()
+                }
+            }
+        }
     }
 
     private fun maybeRequestNotificationPermission() {
@@ -266,7 +442,7 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         val batteryRemindTimeReached = repository.getBatteryOptimizationsRemindTime() < System.currentTimeMillis()
         val ignoringOptimizations = isIgnoringBatteryOptimizations(this@MainActivity)
         val showBanner = hasInstantSubscriptions && batteryRemindTimeReached && !ignoringOptimizations
-        val batteryBanner = findViewById<View>(R.id.main_banner_battery)
+        val batteryBanner = alertsPageView?.findViewById<View>(R.id.main_banner_battery) ?: return
         batteryBanner.visibility = if (showBanner) View.VISIBLE else View.GONE
         Log.d(TAG, "Battery: ignoring optimizations = $ignoringOptimizations (we want this to be true); instant subscriptions = $hasInstantSubscriptions; remind time reached = $batteryRemindTimeReached; banner = $showBanner")
     }
@@ -276,12 +452,13 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         val usingWebSockets = repository.getConnectionProtocol() == Repository.CONNECTION_PROTOCOL_WS
         val wsRemindTimeReached = repository.getWebSocketRemindTime() < System.currentTimeMillis()
         val showBanner = hasSelfHostedSubscriptions && wsRemindTimeReached && !usingWebSockets
-        val wsBanner = findViewById<View>(R.id.main_banner_websocket)
+        val wsBanner = alertsPageView?.findViewById<View>(R.id.main_banner_websocket) ?: return
         wsBanner.visibility = if (showBanner) View.VISIBLE else View.GONE
     }
 
     private fun showHideWebSocketReconnectBanner(subscriptions: List<Subscription>) {
-        val wsReconnectBanner = findViewById<View>(R.id.main_banner_websocket_reconnect)
+        val wsReconnectBanner = alertsPageView?.findViewById<View>(R.id.main_banner_websocket_reconnect)
+            ?: return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val hasSelfHostedSubscriptions = subscriptions.count { it.baseUrl != appBaseUrl } > 0
             val usingWebSockets = repository.getConnectionProtocol() == Repository.CONNECTION_PROTOCOL_WS
@@ -587,7 +764,9 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
             }
             runOnUiThread {
                 Toast.makeText(this@MainActivity, toastMessage, Toast.LENGTH_LONG).show()
-                mainListContainer.isRefreshing = false
+                if (this@MainActivity::mainListContainer.isInitialized) {
+                    mainListContainer.isRefreshing = false
+                }
             }
             Log.d(TAG, "Finished polling for new notifications")
         }

--- a/app/src/main/java/io/heckel/ntfy/ui/MainPagerAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainPagerAdapter.kt
@@ -1,0 +1,34 @@
+package io.heckel.ntfy.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import io.heckel.ntfy.R
+
+class MainPagerAdapter(private val activity: MainActivity) :
+    RecyclerView.Adapter<MainPagerAdapter.PageViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PageViewHolder {
+        val layout = when (viewType) {
+            0 -> R.layout.page_quake_alerts
+            else -> R.layout.page_quake_history
+        }
+        val view = LayoutInflater.from(parent.context).inflate(layout, parent, false)
+        return PageViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: PageViewHolder, position: Int) {
+        if (position == 0) {
+            activity.bindAlertsPage(holder.itemView)
+        } else {
+            activity.bindHistoryPage(holder.itemView)
+        }
+    }
+
+    override fun getItemCount(): Int = 2
+
+    override fun getItemViewType(position: Int): Int = position
+
+    class PageViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryAdapter.kt
@@ -1,0 +1,61 @@
+package io.heckel.ntfy.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.chip.Chip
+import io.heckel.ntfy.R
+
+class QuakeHistoryAdapter :
+    ListAdapter<QuakeHistoryReport, QuakeHistoryAdapter.HistoryViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HistoryViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_quake_history, parent, false)
+        return HistoryViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: HistoryViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class HistoryViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val idChip: Chip = itemView.findViewById(R.id.history_report_id)
+        private val location: TextView = itemView.findViewById(R.id.history_report_location)
+        private val dateTime: TextView = itemView.findViewById(R.id.history_report_datetime)
+        private val magnitude: TextView = itemView.findViewById(R.id.history_report_magnitude)
+        private val depth: TextView = itemView.findViewById(R.id.history_report_depth)
+        private val coordinates: TextView = itemView.findViewById(R.id.history_report_coordinates)
+        private val potential: TextView = itemView.findViewById(R.id.history_report_potential)
+        private val felt: TextView = itemView.findViewById(R.id.history_report_felt)
+
+        fun bind(report: QuakeHistoryReport) {
+            val idText = if (report.id.isBlank()) {
+                itemView.context.getString(R.string.quake_history_no_id)
+            } else {
+                itemView.context.getString(R.string.quake_history_id_prefix, report.id)
+            }
+            idChip.text = idText
+            location.text = report.location.ifBlank { itemView.context.getString(R.string.quake_history_unknown_location) }
+            dateTime.text = report.dateTime.ifBlank { itemView.context.getString(R.string.quake_history_unknown_time) }
+            magnitude.text = report.magnitude.ifBlank { itemView.context.getString(R.string.quake_history_unknown_magnitude) }
+            depth.text = report.depth.ifBlank { itemView.context.getString(R.string.quake_history_unknown_depth) }
+            coordinates.text = report.coordinates.ifBlank { itemView.context.getString(R.string.quake_history_unknown_coordinates) }
+            potential.text = report.potential.ifBlank { itemView.context.getString(R.string.quake_history_no_potential) }
+            felt.visibility = if (report.felt.isBlank()) View.GONE else View.VISIBLE
+            felt.text = report.felt
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<QuakeHistoryReport>() {
+        override fun areItemsTheSame(oldItem: QuakeHistoryReport, newItem: QuakeHistoryReport): Boolean =
+            oldItem.id == newItem.id && oldItem.dateTime == newItem.dateTime
+
+        override fun areContentsTheSame(oldItem: QuakeHistoryReport, newItem: QuakeHistoryReport): Boolean =
+            oldItem == newItem
+    }
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryReport.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryReport.kt
@@ -1,0 +1,12 @@
+package io.heckel.ntfy.ui
+
+data class QuakeHistoryReport(
+    val id: String,
+    val location: String,
+    val dateTime: String,
+    val magnitude: String,
+    val depth: String,
+    val coordinates: String,
+    val potential: String,
+    val felt: String
+)

--- a/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryService.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryService.kt
@@ -1,0 +1,129 @@
+package io.heckel.ntfy.ui
+
+import io.heckel.ntfy.BuildConfig
+import io.heckel.ntfy.util.Log
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+class QuakeHistoryService {
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(15, TimeUnit.SECONDS)
+        .build()
+
+    fun fetchReports(): List<QuakeHistoryReport> {
+        val request = Request.Builder()
+            .url(HISTORY_URL)
+            .header("User-Agent", "quakealert-android/${BuildConfig.VERSION_NAME}")
+            .build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Unexpected HTTP ${response.code}")
+            }
+            val body = response.body?.string()?.trim() ?: return emptyList()
+            if (body.isEmpty()) {
+                return emptyList()
+            }
+            return parseBody(body)
+        }
+    }
+
+    private fun parseBody(body: String): List<QuakeHistoryReport> {
+        return try {
+            when {
+                body.startsWith("[") -> parseArray(JSONArray(body))
+                body.startsWith("{") -> parseObject(JSONObject(body))
+                else -> emptyList()
+            }
+        } catch (exception: Exception) {
+            Log.e(TAG, "Unable to parse quake history", exception)
+            emptyList()
+        }
+    }
+
+    private fun parseObject(root: JSONObject): List<QuakeHistoryReport> {
+        val arrayKeys = listOf("data", "laporan", "reports", "result")
+        val nestedArray = arrayKeys.firstNotNullOfOrNull { key ->
+            root.optJSONArray(key)
+        }
+        return if (nestedArray != null) {
+            parseArray(nestedArray)
+        } else {
+            // Some APIs wrap entries in objects keyed by IDs
+            val list = mutableListOf<QuakeHistoryReport>()
+            val iterator = root.keys()
+            while (iterator.hasNext()) {
+                val key = iterator.next()
+                val value = root.optJSONObject(key) ?: continue
+                list += parseReport(value, key)
+            }
+            list
+        }
+    }
+
+    private fun parseArray(array: JSONArray): List<QuakeHistoryReport> {
+        val list = mutableListOf<QuakeHistoryReport>()
+        for (i in 0 until array.length()) {
+            val obj = array.optJSONObject(i) ?: continue
+            list += parseReport(obj)
+        }
+        return list
+    }
+
+    private fun parseReport(obj: JSONObject, fallbackId: String? = null): QuakeHistoryReport {
+        val id = obj.optString("id").takeUnless { it.isBlank() }
+            ?: obj.optString("ID").takeUnless { it.isBlank() }
+            ?: fallbackId
+            ?: listOf(
+                obj.optString("EventID"),
+                obj.optString("event_id"),
+                obj.optString("shakemap"),
+                obj.optString("date")
+            ).firstOrNull { it.isNotBlank() } ?: ""
+
+        val tanggal = obj.optString("Tanggal", obj.optString("tanggal"))
+        val jam = obj.optString("Jam", obj.optString("jam"))
+        val datetime = obj.optString("DateTime", obj.optString("datetime"))
+        val reportedAt = when {
+            datetime.isNotBlank() -> datetime
+            tanggal.isNotBlank() && jam.isNotBlank() -> "$tanggal $jam"
+            tanggal.isNotBlank() -> tanggal
+            else -> jam
+        }
+
+        val magnitude = obj.optString("Magnitude", obj.optString("magnitudo", obj.optString("magnitude")))
+        val depth = obj.optString("Kedalaman", obj.optString("kedalaman", obj.optString("depth")))
+        val lintang = obj.optString("Lintang", obj.optString("lintang"))
+        val bujur = obj.optString("Bujur", obj.optString("bujur"))
+        val coords = obj.optString("coordinates")
+        val location = obj.optString("Wilayah", obj.optString("wilayah", obj.optString("area", obj.optString("lokasi"))))
+        val potential = obj.optString("Potensi", obj.optString("potensi", obj.optString("potential")))
+        val felt = obj.optString("Dirasakan", obj.optString("dirasakan", obj.optString("felt")))
+
+        val formattedCoordinates = when {
+            coords.isNotBlank() -> coords
+            lintang.isNotBlank() || bujur.isNotBlank() -> listOf(lintang, bujur).filter { it.isNotBlank() }.joinToString(" ")
+            else -> ""
+        }
+
+        return QuakeHistoryReport(
+            id = id,
+            location = location,
+            dateTime = reportedAt,
+            magnitude = if (magnitude.isNotBlank()) "M $magnitude" else "",
+            depth = depth,
+            coordinates = formattedCoordinates,
+            potential = potential,
+            felt = felt
+        )
+    }
+
+    companion object {
+        private const val TAG = "QuakeHistoryService"
+        private const val HISTORY_URL = "https://quakealert.bananapixel.my.id/laporan"
+    }
+}

--- a/app/src/main/res/drawable/ic_history_coordinate.xml
+++ b/app/src/main/res/drawable/ic_history_coordinate.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/teal_dark">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z" />
+</vector>

--- a/app/src/main/res/drawable/ic_history_depth.xml
+++ b/app/src/main/res/drawable/ic_history_depth.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/teal_dark">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,5v3h-3v7h3l-4,4 -4,-4h3V8H8V5h8z" />
+</vector>

--- a/app/src/main/res/drawable/ic_history_magnitude.xml
+++ b/app/src/main/res/drawable/ic_history_magnitude.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/teal_dark">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20.38,8.57L18.99,6.86 15.96,9.62 13.47,6 9.53,10.94 7.14,8.56 3,14h18l-0.62,-0.83z" />
+</vector>

--- a/app/src/main/res/drawable/ic_tab_quake_alerts.xml
+++ b/app/src/main/res/drawable/ic_tab_quake_alerts.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/teal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.9,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,3c0,-0.83 -0.67,-1.5 -1.5,-1.5S10.5,2.17 10.5,3l0,1.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_tab_quake_history.xml
+++ b/app/src/main/res/drawable/ic_tab_quake_history.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/teal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M13,3c-4.97,0 -9,4.03 -9,9s4.03,9 9,9 9,-4.03 9,-9 -4.03,-9 -9,-9zM13,19c-3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6 6,2.69 6,6 -2.69,6 -6,6zM12,7h-1v6l5.25,3.15 0.75,-1.23 -5,-2.92z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,290 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                   xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-                                                   android:layout_height="match_parent">
-
-    <com.google.android.material.card.MaterialCardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:shapeAppearance="?shapeAppearanceLargeComponent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:id="@+id/main_banner_battery"
-            android:visibility="visible"
-    >
-        <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/main_banner_battery_constraint" android:elevation="5dp">
-
-            <ImageView
-                    android:layout_width="28dp"
-                    android:layout_height="28dp" app:srcCompat="@drawable/ic_battery_alert_red_24dp"
-                    android:id="@+id/main_banner_battery_image"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/main_banner_battery_text"
-                    app:layout_constraintEnd_toStartOf="@id/main_banner_battery_text"
-                    app:layout_constraintBottom_toBottomOf="@+id/main_banner_battery_text"
-                    android:layout_marginStart="15dp"/>
-            <TextView
-                    android:id="@+id/main_banner_battery_text"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_battery_text"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Small"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    android:layout_marginEnd="15dp" android:layout_marginTop="15dp"
-                    app:layout_constraintStart_toEndOf="@+id/main_banner_battery_image"
-                    android:layout_marginStart="10dp"/>
-
-            <androidx.constraintlayout.helper.widget.Flow
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:constraint_referenced_ids="main_banner_battery_ask_later,main_banner_battery_dontaskagain,main_banner_battery_fix_now"
-                    app:layout_constraintTop_toBottomOf="@id/main_banner_battery_text"
-                    app:flow_horizontalAlign="end"
-                    app:flow_wrapMode="chain"
-                    app:flow_horizontalStyle="packed"
-                    android:layout_marginEnd="15dp"
-                    android:id="@+id/main_banner_battery_flow"
-                    app:layout_constraintStart_toStartOf="parent"
-                    android:layout_marginStart="15dp"
-                    app:flow_horizontalBias="1"
-                    app:flow_verticalGap="0dp" app:flow_horizontalGap="0dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_battery_ask_later"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_battery_button_remind_later"
-                    tools:layout_editor_absoluteX="15dp" tools:layout_editor_absoluteY="67dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_battery_dontaskagain"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_battery_button_dismiss"
-                    tools:layout_editor_absoluteX="142dp" tools:layout_editor_absoluteY="71dp"/>
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_battery_fix_now"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_battery_button_fix_now"
-                    tools:layout_editor_absoluteX="269dp" tools:layout_editor_absoluteY="67dp"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-
-    <com.google.android.material.card.MaterialCardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:shapeAppearance="?shapeAppearanceLargeComponent" app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" app:layout_constraintTop_toBottomOf="@+id/main_banner_battery"
-            android:id="@+id/main_banner_websocket" android:visibility="visible">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/main_banner_websocket_constraint" android:elevation="5dp">
-
-            <ImageView
-                    android:layout_width="28dp"
-                    android:layout_height="28dp" app:srcCompat="@drawable/ic_announcement_orange_24dp"
-                    android:id="@+id/main_banner_websocket_image"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/main_banner_websocket_text"
-                    app:layout_constraintEnd_toStartOf="@id/main_banner_websocket_text"
-                    app:layout_constraintBottom_toBottomOf="@+id/main_banner_websocket_text"
-                    android:layout_marginStart="15dp"/>
-            <TextView
-                    android:id="@+id/main_banner_websocket_text"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_websocket_text"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Small"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    android:layout_marginEnd="15dp" android:layout_marginTop="15dp"
-                    app:layout_constraintStart_toEndOf="@+id/main_banner_websocket_image"
-                    android:layout_marginStart="10dp"
-            />
-
-            <androidx.constraintlayout.helper.widget.Flow
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:constraint_referenced_ids="main_banner_websocket_remind_later,main_banner_websocket_dontaskagain,main_banner_websocket_enable" app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_text" app:flow_horizontalAlign="end" app:flow_wrapMode="chain" app:flow_horizontalStyle="packed" android:layout_marginEnd="15dp" android:id="@+id/flow" app:layout_constraintStart_toStartOf="parent" android:layout_marginStart="15dp" app:flow_horizontalBias="1"
-                    app:flow_verticalGap="0dp" app:flow_horizontalGap="0dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_websocket_remind_later"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_websocket_button_remind_later"
-                    tools:layout_editor_absoluteX="86dp" tools:layout_editor_absoluteY="83dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_websocket_dontaskagain"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_websocket_button_dismiss"
-                    tools:layout_editor_absoluteX="260dp" tools:layout_editor_absoluteY="83dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_websocket_enable"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_websocket_button_enable_now"
-                    tools:layout_editor_absoluteX="253dp" tools:layout_editor_absoluteY="131dp"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-
-    <com.google.android.material.card.MaterialCardView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:shapeAppearance="?shapeAppearanceLargeComponent" app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" app:layout_constraintTop_toBottomOf="@+id/main_banner_websocket"
-        android:id="@+id/main_banner_websocket_reconnect" android:visibility="visible">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/main_banner_websocket_reconnect_constraint" android:elevation="5dp">
-
-            <ImageView
-                android:layout_width="28dp"
-                android:layout_height="28dp" app:srcCompat="@drawable/ic_announcement_orange_24dp"
-                android:id="@+id/main_banner_websocket_reconnect_image"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/main_banner_websocket_reconnect_text"
-                app:layout_constraintEnd_toStartOf="@id/main_banner_websocket_reconnect_text"
-                app:layout_constraintBottom_toBottomOf="@+id/main_banner_websocket_reconnect_text"
-                android:layout_marginStart="15dp"/>
-            <TextView
-                android:id="@+id/main_banner_websocket_reconnect_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/main_banner_websocket_reconnect_text"
-                android:textAppearance="@style/TextAppearance.AppCompat.Small"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:layout_marginEnd="15dp" android:layout_marginTop="15dp"
-                app:layout_constraintStart_toEndOf="@+id/main_banner_websocket_reconnect_image"
-                android:layout_marginStart="10dp"
-                />
-
-            <androidx.constraintlayout.helper.widget.Flow
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:constraint_referenced_ids="main_banner_websocket_reconnect_remind_later,main_banner_websocket_reconnect_dontaskagain,main_banner_websocket_reconnect_enable" app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect_text" app:flow_horizontalAlign="end" app:flow_wrapMode="chain" app:flow_horizontalStyle="packed" android:layout_marginEnd="15dp" android:id="@+id/flow_reconnect" app:layout_constraintStart_toStartOf="parent" android:layout_marginStart="15dp" app:flow_horizontalBias="1"
-                app:flow_verticalGap="0dp" app:flow_horizontalGap="0dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/main_banner_websocket_reconnect_remind_later"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/main_banner_websocket_reconnect_button_remind_later"
-                tools:layout_editor_absoluteX="86dp" tools:layout_editor_absoluteY="83dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/main_banner_websocket_reconnect_dontaskagain"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/main_banner_websocket_reconnect_button_dismiss"
-                tools:layout_editor_absoluteX="260dp" tools:layout_editor_absoluteY="83dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/main_banner_websocket_reconnect_enable"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/main_banner_websocket_reconnect_button_enable_now"
-                tools:layout_editor_absoluteX="253dp" tools:layout_editor_absoluteY="131dp"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/main_subscriptions_list_container"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:visibility="visible"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect">
-        <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/main_subscriptions_list"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clickable="true"
-                android:focusable="true"
-                android:paddingTop="5dp"
-                android:paddingBottom="5dp"
-                android:clipToPadding="false"
-                android:background="?android:attr/selectableItemBackground"
-                app:layoutManager="LinearLayoutManager"/>
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.MainActivity">
 
     <LinearLayout
-            android:orientation="vertical"
+        android:id="@+id/main_root_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/main_tab_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/fab" app:layout_constraintStart_toStartOf="parent"
-            android:id="@+id/main_no_subscriptions" android:visibility="gone">
-        <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" app:srcCompat="@drawable/ic_sms_gray_48dp"
-                android:id="@+id/main_no_subscriptions_image"/>
-        <TextView
-                android:id="@+id/main_no_subscriptions_text"
-                android:text="@string/main_no_subscriptions_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                android:padding="10dp" android:gravity="center_horizontal"
-                android:paddingStart="50dp" android:paddingEnd="50dp"/>
-        <TextView
-                android:text="@string/main_how_to_intro"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/main_how_to_intro"
-                android:layout_marginTop="20dp"
-                android:layout_marginStart="50dp"
-                android:layout_marginEnd="50dp"/>
-        <TextView
-                android:text="@string/main_how_to_link"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/main_how_to_link"
-                android:layout_marginTop="7dp"
-                android:layout_marginStart="50dp"
-                android:layout_marginEnd="50dp"
-                android:linksClickable="true"
-                android:autoLink="web"/>
+            android:layout_height="wrap_content"
+            android:background="?attr/colorSurface"
+            app:tabIndicatorColor="@color/teal"
+            app:tabSelectedTextColor="@color/teal"
+            app:tabTextColor="?attr/colorOnSurface"
+            app:tabMode="fixed"
+            app:tabGravity="fill" />
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/main_view_pager"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:overScrollMode="never" />
     </LinearLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="24dp"
-            android:contentDescription="@string/main_add_button_description"
-            android:src="@drawable/ic_add_black_24dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            style="@style/FloatingActionButton"
-    />
+        android:id="@+id/fab"
+        style="@style/FloatingActionButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="24dp"
+        android:contentDescription="@string/main_add_button_description"
+        android:src="@drawable/ic_add_black_24dp"
+        app:layout_anchorGravity="bottom|end"
+        android:layout_gravity="bottom|end" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_quake_history.xml
+++ b/app/src/main/res/layout/item_quake_history.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    android:layout_marginTop="0dp"
+    app:cardBackgroundColor="@color/cardview_light_background"
+    app:cardElevation="2dp"
+    app:shapeAppearance="?shapeAppearanceLargeComponent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="16dp"
+        android:paddingTop="16dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="16dp">
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/history_report_id"
+            style="@style/Widget.MaterialComponents.Chip.Assist"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checkable="false"
+            android:clickable="false"
+            android:focusable="false"
+            android:text="ID"
+            app:chipBackgroundColor="@color/teal_light"
+            app:chipIcon="@drawable/ic_tab_quake_history"
+            app:chipIconTint="@color/black"
+            app:chipStrokeColor="@color/teal_dark"
+            app:chipStrokeWidth="1dp"
+            app:textAppearance="@style/TextAppearance.MaterialComponents.Caption" />
+
+        <TextView
+            android:id="@+id/history_report_location"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textStyle="bold"
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="18sp"
+            android:text="Location" />
+
+        <TextView
+            android:id="@+id/history_report_datetime"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="Date &amp; Time"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:contentDescription="@string/quake_history_magnitude_icon_description"
+                    android:src="@drawable/ic_history_magnitude" />
+
+                <TextView
+                    android:id="@+id/history_report_magnitude"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:text="M 0.0"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:contentDescription="@string/quake_history_depth_icon_description"
+                    android:src="@drawable/ic_history_depth" />
+
+                <TextView
+                    android:id="@+id/history_report_depth"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:text="Depth"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                    android:textStyle="bold" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:contentDescription="@string/quake_history_coordinate_icon_description"
+                android:src="@drawable/ic_history_coordinate" />
+
+            <TextView
+                android:id="@+id/history_report_coordinates"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="Coordinates"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/history_report_potential"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="Potential"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textStyle="italic" />
+
+        <TextView
+            android:id="@+id/history_report_felt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Felt"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/page_quake_alerts.xml
+++ b/app/src/main/res/layout/page_quake_alerts.xml
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/main_banner_battery"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="visible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:shapeAppearance="?shapeAppearanceLargeComponent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/main_banner_battery_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="5dp">
+
+            <ImageView
+                android:id="@+id/main_banner_battery_image"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_marginStart="15dp"
+                app:layout_constraintBottom_toBottomOf="@+id/main_banner_battery_text"
+                app:layout_constraintEnd_toStartOf="@id/main_banner_battery_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/main_banner_battery_text"
+                app:srcCompat="@drawable/ic_battery_alert_red_24dp" />
+
+            <TextView
+                android:id="@+id/main_banner_battery_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="15dp"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="15dp"
+                android:text="@string/main_banner_battery_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/main_banner_battery_image"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/main_banner_battery_flow"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="15dp"
+                android:layout_marginStart="15dp"
+                app:constraint_referenced_ids="main_banner_battery_ask_later,main_banner_battery_dontaskagain,main_banner_battery_fix_now"
+                app:flow_horizontalAlign="end"
+                app:flow_horizontalBias="1"
+                app:flow_horizontalGap="0dp"
+                app:flow_horizontalStyle="packed"
+                app:flow_verticalGap="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/main_banner_battery_text" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_battery_ask_later"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_battery_button_remind_later"
+                tools:layout_editor_absoluteX="15dp"
+                tools:layout_editor_absoluteY="67dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_battery_dontaskagain"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_battery_button_dismiss"
+                tools:layout_editor_absoluteX="142dp"
+                tools:layout_editor_absoluteY="71dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_battery_fix_now"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_battery_button_fix_now"
+                tools:layout_editor_absoluteX="269dp"
+                tools:layout_editor_absoluteY="67dp" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/main_banner_websocket"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="visible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/main_banner_battery"
+        app:shapeAppearance="?shapeAppearanceLargeComponent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/main_banner_websocket_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="5dp">
+
+            <ImageView
+                android:id="@+id/main_banner_websocket_image"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_marginStart="15dp"
+                app:layout_constraintBottom_toBottomOf="@+id/main_banner_websocket_text"
+                app:layout_constraintEnd_toStartOf="@id/main_banner_websocket_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/main_banner_websocket_text"
+                app:srcCompat="@drawable/ic_announcement_orange_24dp" />
+
+            <TextView
+                android:id="@+id/main_banner_websocket_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="15dp"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="15dp"
+                android:text="@string/main_banner_websocket_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/main_banner_websocket_image"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/flow"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="15dp"
+                android:layout_marginStart="15dp"
+                app:constraint_referenced_ids="main_banner_websocket_remind_later,main_banner_websocket_dontaskagain,main_banner_websocket_enable"
+                app:flow_horizontalAlign="end"
+                app:flow_horizontalBias="1"
+                app:flow_horizontalGap="0dp"
+                app:flow_horizontalStyle="packed"
+                app:flow_verticalGap="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_text" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_remind_later"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_button_remind_later"
+                tools:layout_editor_absoluteX="86dp"
+                tools:layout_editor_absoluteY="83dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_dontaskagain"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_button_dismiss"
+                tools:layout_editor_absoluteX="260dp"
+                tools:layout_editor_absoluteY="83dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_enable"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_button_enable_now"
+                tools:layout_editor_absoluteX="253dp"
+                tools:layout_editor_absoluteY="131dp" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/main_banner_websocket_reconnect"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="visible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/main_banner_websocket"
+        app:shapeAppearance="?shapeAppearanceLargeComponent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/main_banner_websocket_reconnect_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="5dp">
+
+            <ImageView
+                android:id="@+id/main_banner_websocket_reconnect_image"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_marginStart="15dp"
+                app:layout_constraintBottom_toBottomOf="@+id/main_banner_websocket_reconnect_text"
+                app:layout_constraintEnd_toStartOf="@id/main_banner_websocket_reconnect_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/main_banner_websocket_reconnect_text"
+                app:srcCompat="@drawable/ic_announcement_orange_24dp" />
+
+            <TextView
+                android:id="@+id/main_banner_websocket_reconnect_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="15dp"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="15dp"
+                android:text="@string/main_banner_websocket_reconnect_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/main_banner_websocket_reconnect_image"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/flow_reconnect"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="15dp"
+                android:layout_marginStart="15dp"
+                app:constraint_referenced_ids="main_banner_websocket_reconnect_remind_later,main_banner_websocket_reconnect_dontaskagain,main_banner_websocket_reconnect_enable"
+                app:flow_horizontalAlign="end"
+                app:flow_horizontalBias="1"
+                app:flow_horizontalGap="0dp"
+                app:flow_horizontalStyle="packed"
+                app:flow_verticalGap="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect_text" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_reconnect_remind_later"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_button_remind_later"
+                tools:layout_editor_absoluteX="86dp"
+                tools:layout_editor_absoluteY="83dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_reconnect_dontaskagain"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_button_dismiss"
+                tools:layout_editor_absoluteX="260dp"
+                tools:layout_editor_absoluteY="83dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_reconnect_enable"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_button_enable_now"
+                tools:layout_editor_absoluteX="253dp"
+                tools:layout_editor_absoluteY="131dp" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/main_subscriptions_list_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/main_subscriptions_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?android:attr/selectableItemBackground"
+            android:clickable="true"
+            android:clipToPadding="false"
+            android:focusable="true"
+            android:paddingBottom="5dp"
+            android:paddingTop="5dp"
+            app:layoutManager="LinearLayoutManager" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <LinearLayout
+        android:id="@+id/main_no_subscriptions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/main_no_subscriptions_image"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:srcCompat="@drawable/ic_sms_gray_48dp" />
+
+        <TextView
+            android:id="@+id/main_no_subscriptions_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:padding="10dp"
+            android:paddingStart="50dp"
+            android:paddingEnd="50dp"
+            android:text="@string/main_no_subscriptions_text"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+        <TextView
+            android:id="@+id/main_how_to_intro"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="50dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="50dp"
+            android:text="@string/main_how_to_intro" />
+
+        <TextView
+            android:id="@+id/main_how_to_link"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="50dp"
+            android:layout_marginTop="7dp"
+            android:layout_marginEnd="50dp"
+            android:autoLink="web"
+            android:linksClickable="true"
+            android:text="@string/main_how_to_link" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/page_quake_history.xml
+++ b/app/src/main/res/layout/page_quake_history.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="0dp">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/quake_history_refresh"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/quake_history_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingStart="16dp"
+            android:paddingTop="16dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="32dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:listitem="@layout/item_quake_history" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <ProgressBar
+        android:id="@+id/quake_history_progress"
+        style="@style/Widget.MaterialComponents.ProgressIndicator.Circular.Indeterminate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/quake_history_empty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingStart="32dp"
+        android:paddingEnd="32dp"
+        android:text="@string/quake_history_empty"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/quake_history_error"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingStart="32dp"
+        android:paddingTop="16dp"
+        android:paddingEnd="32dp"
+        android:text="@string/quake_history_error"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:textColor="@color/design_default_color_error"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,23 @@
     <string name="refresh_message_error_one">Could not refresh subscription: %1$s</string>
 
     <!-- Main activity: Action bar -->
-    <string name="main_action_bar_title">Subscribed topics</string>
+    <string name="main_action_bar_title">Subscribed Topics to Quake Alerts</string>
+    <string name="main_tab_alerts">Quake Alerts</string>
+    <string name="main_tab_history">Quake History Reports</string>
+    <string name="quake_history_title">Quake History Reports</string>
+    <string name="quake_history_empty">We can't find any history reports right now. Try refreshing in a moment.</string>
+    <string name="quake_history_error">Unable to load quake history. Check your connection and pull to refresh.</string>
+    <string name="quake_history_magnitude_icon_description">Magnitude icon</string>
+    <string name="quake_history_depth_icon_description">Depth icon</string>
+    <string name="quake_history_coordinate_icon_description">Location icon</string>
+    <string name="quake_history_no_id">No ID</string>
+    <string name="quake_history_id_prefix">ID: %1$s</string>
+    <string name="quake_history_unknown_location">Unknown location</string>
+    <string name="quake_history_unknown_time">Unknown time</string>
+    <string name="quake_history_unknown_magnitude">Magnitude unavailable</string>
+    <string name="quake_history_unknown_depth">Depth unavailable</string>
+    <string name="quake_history_unknown_coordinates">Coordinates unavailable</string>
+    <string name="quake_history_no_potential">No potential impact reported</string>
     <string name="main_menu_notifications_enabled">Notifications on</string>
     <string name="main_menu_notifications_disabled_forever">Notifications muted</string>
     <string name="main_menu_notifications_disabled_until">Notifications muted until %1$s</string>


### PR DESCRIPTION
## Summary
- add a tabbed navigation bar that swaps between the alerts list and a new history view
- move the existing alerts UI into a dedicated pager layout and update strings for the Quake Alerts tab
- build the quake history experience with cards, swipe refresh, empty/error states, and a service/adapter to load remote data

## Testing
- ./gradlew lint *(fails: Android SDK not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc5d22670832d9270af5b5458a260