### PR TITLE
Handle optional google services config and fix quake history string

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,18 @@ repositories {
 }
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'com.google.gms.google-services'
+
+def hasGoogleServicesJson = fileTree(projectDir) {
+    include 'google-services.json'
+    include 'src/**/google-services.json'
+    exclude 'build/**'
+}.files.any()
+
+if (hasGoogleServicesJson) {
+    apply plugin: 'com.google.gms.google-services'
+} else {
+    logger.lifecycle('google-services.json not found. Skipping Google Services plugin.')
+}
 
 android {
     namespace "io.heckel.ntfy"
@@ -76,8 +87,10 @@ android {
 // Disables GoogleServices tasks for F-Droid variant
 android.applicationVariants.all { variant ->
     def shouldProcessGoogleServices = variant.flavorName == "play"
-    def googleTask = tasks.findByName("process${variant.name.capitalize()}GoogleServices")
-    googleTask.enabled = shouldProcessGoogleServices
+    def googleTaskName = "process${variant.name.capitalize()}GoogleServices"
+    tasks.matching { it.name == googleTaskName }.configureEach {
+        it.enabled = shouldProcessGoogleServices
+    }
 }
 
 dependencies {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,7 +38,7 @@
     <string name="main_tab_alerts">Quake Alerts</string>
     <string name="main_tab_history">Quake History Reports</string>
     <string name="quake_history_title">Quake History Reports</string>
-    <string name="quake_history_empty">We can't find any history reports right now. Try refreshing in a moment.</string>
+    <string name="quake_history_empty">We can\'t find any history reports right now. Try refreshing in a moment.</string>
     <string name="quake_history_error">Unable to load quake history. Check your connection and pull to refresh.</string>
     <string name="quake_history_magnitude_icon_description">Magnitude icon</string>
     <string name="quake_history_depth_icon_description">Depth icon</string>


### PR DESCRIPTION
## Summary
- apply the Google Services Gradle plugin only when a google-services.json file exists to prevent build failures in public clones
- guard the Google Services processing tasks so only Play builds are enabled when the plugin is present
- escape the apostrophe in the new quake history empty-state string so AAPT can compile the resources

## Testing
- ./gradlew :app:mergePlayDebugResources *(fails: dependency downloads blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd03f78f0832db736ec8822489ea6