### PR TITLE
Add bottom navigation and quake history screen

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/history/QuakeHistoryRepository.kt
+++ b/app/src/main/java/io/heckel/ntfy/history/QuakeHistoryRepository.kt
@@ -1,0 +1,106 @@
+package io.heckel.ntfy.history
+
+import io.heckel.ntfy.msg.ApiService
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+class QuakeHistoryRepository {
+    private val client = OkHttpClient.Builder()
+        .callTimeout(15, TimeUnit.SECONDS)
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(15, TimeUnit.SECONDS)
+        .build()
+
+    @Throws(IOException::class)
+    fun fetchReports(): List<QuakeReport> {
+        val request = Request.Builder()
+            .url(HISTORY_URL)
+            .addHeader("User-Agent", ApiService.USER_AGENT)
+            .build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Unexpected response ${response.code}")
+            }
+            val body = response.body?.string()?.trim().orEmpty()
+            if (body.isEmpty()) {
+                return emptyList()
+            }
+            return parseReports(body)
+        }
+    }
+
+    private fun parseReports(json: String): List<QuakeReport> {
+        val array = when {
+            json.startsWith("[") -> JSONArray(json)
+            json.startsWith("{") -> {
+                val root = JSONObject(json)
+                extractArray(root) ?: JSONArray().apply { put(root) }
+            }
+            else -> JSONArray()
+        }
+        val reports = mutableListOf<QuakeReport>()
+        for (i in 0 until array.length()) {
+            val item = array.optJSONObject(i) ?: continue
+            reports.add(parseObject(item))
+        }
+        return reports
+    }
+
+    private fun extractArray(root: JSONObject): JSONArray? {
+        val candidates = listOf("laporan", "data", "results", "items", "records")
+        candidates.forEach { key ->
+            if (root.has(key)) {
+                val value = root.get(key)
+                when (value) {
+                    is JSONArray -> return value
+                    is JSONObject -> {
+                        extractArray(value)?.let { return it }
+                        value.optJSONArray("records")?.let { return it }
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    private fun parseObject(obj: JSONObject): QuakeReport {
+        val coordinateObject = obj.optJSONObject("coordinates")
+        val latitude = coordinateObject?.optStringOrNull("lintang", "latitude")
+            ?: obj.optStringOrNull("lintang", "latitude")
+        val longitude = coordinateObject?.optStringOrNull("bujur", "longitude")
+            ?: obj.optStringOrNull("bujur", "longitude")
+        return QuakeReport(
+            date = obj.optStringOrNull("tanggal", "date", "day"),
+            time = obj.optStringOrNull("jam", "time", "clock"),
+            magnitude = obj.optStringOrNull("magnitudo", "magnitude", "mag"),
+            depth = obj.optStringOrNull("kedalaman", "depth"),
+            location = obj.optStringOrNull("wilayah", "location", "region", "place"),
+            potential = obj.optStringOrNull("potensi", "potential", "warning"),
+            felt = obj.optStringOrNull("dirasakan", "felt", "impact"),
+            latitude = latitude,
+            longitude = longitude,
+            source = obj.optStringOrNull("source", "sumber", "provider"),
+            eventId = obj.optStringOrNull("eventid", "event_id", "id")
+        )
+    }
+
+    private fun JSONObject.optStringOrNull(vararg names: String): String? {
+        names.forEach { name ->
+            if (has(name)) {
+                val value = optString(name, "").trim()
+                if (value.isNotEmpty()) {
+                    return value
+                }
+            }
+        }
+        return null
+    }
+
+    companion object {
+        private const val HISTORY_URL = "https://quakealert.bananapixel.my.id/laporan"
+    }
+}

--- a/app/src/main/java/io/heckel/ntfy/history/QuakeReport.kt
+++ b/app/src/main/java/io/heckel/ntfy/history/QuakeReport.kt
@@ -1,0 +1,33 @@
+package io.heckel.ntfy.history
+
+data class QuakeReport(
+    val date: String?,
+    val time: String?,
+    val magnitude: String?,
+    val depth: String?,
+    val location: String?,
+    val potential: String?,
+    val felt: String?,
+    val latitude: String?,
+    val longitude: String?,
+    val source: String?,
+    val eventId: String?
+) {
+    val coordinates: String?
+        get() {
+            val lat = latitude?.trim().orEmpty()
+            val lon = longitude?.trim().orEmpty()
+            return when {
+                lat.isNotEmpty() && lon.isNotEmpty() -> "$lat / $lon"
+                lat.isNotEmpty() -> lat
+                lon.isNotEmpty() -> lon
+                else -> null
+            }
+        }
+
+    val header: String
+        get() {
+            val parts = listOfNotNull(date?.trim()?.takeIf { it.isNotEmpty() }, time?.trim()?.takeIf { it.isNotEmpty() })
+            return parts.joinToString(" • ")
+        }
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -30,7 +30,9 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.work.*
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import io.heckel.ntfy.BuildConfig
 import io.heckel.ntfy.R
 import io.heckel.ntfy.app.Application
@@ -43,6 +45,9 @@ import io.heckel.ntfy.msg.DownloadType
 import io.heckel.ntfy.msg.NotificationDispatcher
 import io.heckel.ntfy.service.SubscriberService
 import io.heckel.ntfy.service.SubscriberServiceManager
+import io.heckel.ntfy.history.QuakeReport
+import io.heckel.ntfy.ui.history.QuakeHistoryAdapter
+import io.heckel.ntfy.ui.history.QuakeHistoryViewModel
 import io.heckel.ntfy.util.*
 import io.heckel.ntfy.work.DeleteWorker
 import io.heckel.ntfy.work.PollWorker
@@ -57,6 +62,7 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
     private val viewModel by viewModels<SubscriptionsViewModel> {
         SubscriptionsViewModelFactory((application as Application).repository)
     }
+    private val historyViewModel by viewModels<QuakeHistoryViewModel>()
     private val repository by lazy { (application as Application).repository }
     private val api = ApiService()
     private val messenger = FirebaseMessenger()
@@ -67,6 +73,13 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
     private lateinit var mainListContainer: SwipeRefreshLayout
     private lateinit var adapter: MainAdapter
     private lateinit var fab: FloatingActionButton
+    private lateinit var alertsContainer: View
+    private lateinit var bottomNavigation: BottomNavigationView
+    private lateinit var historyContainer: SwipeRefreshLayout
+    private lateinit var historyList: RecyclerView
+    private lateinit var historyAdapter: QuakeHistoryAdapter
+    private lateinit var historyProgress: CircularProgressIndicator
+    private lateinit var historyError: TextView
 
     // Other stuff
     private var actionMode: ActionMode? = null
@@ -78,6 +91,17 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        alertsContainer = findViewById(R.id.main_alerts_container)
+        bottomNavigation = findViewById(R.id.bottom_navigation)
+        historyContainer = findViewById(R.id.history_list_container)
+        historyList = findViewById(R.id.history_list)
+        historyProgress = findViewById(R.id.history_progress)
+        historyError = findViewById(R.id.history_error)
+        historyAdapter = QuakeHistoryAdapter()
+        historyList.adapter = historyAdapter
+        historyContainer.setColorSchemeResources(Colors.refreshProgressIndicator)
+        historyContainer.setOnRefreshListener { historyViewModel.refresh() }
+
         Log.init(this) // Init logs in all entry points
         Log.d(TAG, "Create $this")
 
@@ -87,7 +111,7 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         appBaseUrl = getString(R.string.app_base_url)
 
         // Action bar
-        title = getString(R.string.main_action_bar_title)
+        title = getString(R.string.main_quake_alerts_title)
 
         // Floating action button ("+")
         fab = findViewById(R.id.fab)
@@ -154,10 +178,50 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
             }
         }
 
+        historyViewModel.reports.observe(this) { reports ->
+            historyAdapter.submitList(reports)
+            updateHistoryMessage(historyViewModel.uiState.value, reports)
+        }
+
+        historyViewModel.uiState.observe(this) { state ->
+            if (!state.loading && historyContainer.isRefreshing) {
+                historyContainer.isRefreshing = false
+            }
+            if (bottomNavigation.selectedItemId == R.id.navigation_history) {
+                historyProgress.visibility = if (state.loading && !historyContainer.isRefreshing) View.VISIBLE else View.GONE
+            } else if (!state.loading) {
+                historyProgress.visibility = View.GONE
+            }
+            updateHistoryMessage(state, historyViewModel.reports.value ?: emptyList())
+        }
+
         // React to changes in instant delivery setting
         viewModel.listIdsWithInstantStatus().observe(this) {
             SubscriberServiceManager.refresh(this)
         }
+
+        bottomNavigation.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.navigation_alerts -> {
+                    showAlerts()
+                    true
+                }
+                R.id.navigation_history -> {
+                    showHistory()
+                    true
+                }
+                else -> false
+            }
+        }
+        bottomNavigation.setOnItemReselectedListener { item ->
+            when (item.itemId) {
+                R.id.navigation_alerts -> mainList.smoothScrollToPosition(0)
+                R.id.navigation_history -> historyList.smoothScrollToPosition(0)
+            }
+        }
+        val selectedNavigation = savedInstanceState?.getInt(STATE_SELECTED_NAVIGATION, R.id.navigation_alerts)
+            ?: R.id.navigation_alerts
+        bottomNavigation.selectedItemId = selectedNavigation
 
         // Battery banner
         val batteryBanner = findViewById<View>(R.id.main_banner_battery) // Banner visibility is toggled in onResume()
@@ -255,10 +319,65 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         }
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(STATE_SELECTED_NAVIGATION, bottomNavigation.selectedItemId)
+    }
+
     override fun onResume() {
         super.onResume()
         showHideNotificationMenuItems()
         redrawList()
+    }
+
+    private fun showAlerts() {
+        alertsContainer.visibility = View.VISIBLE
+        historyContainer.visibility = View.GONE
+        if (historyContainer.isRefreshing) {
+            historyContainer.isRefreshing = false
+        }
+        historyProgress.visibility = View.GONE
+        historyError.visibility = View.GONE
+        title = getString(R.string.main_quake_alerts_title)
+    }
+
+    private fun showHistory() {
+        alertsContainer.visibility = View.GONE
+        historyContainer.visibility = View.VISIBLE
+        val state = historyViewModel.uiState.value
+        historyProgress.visibility = if (state?.loading == true && !historyContainer.isRefreshing) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
+        updateHistoryMessage(state, historyViewModel.reports.value ?: emptyList())
+        title = getString(R.string.main_quake_history_title)
+        historyViewModel.loadInitial()
+    }
+
+    private fun updateHistoryMessage(
+        state: QuakeHistoryViewModel.HistoryUiState?,
+        reports: List<QuakeReport>
+    ) {
+        if (state?.loading == true) {
+            if (!historyContainer.isRefreshing) {
+                historyError.visibility = View.GONE
+            }
+            return
+        }
+        when {
+            state?.errorMessage != null -> {
+                historyError.visibility = View.VISIBLE
+                historyError.text = getString(R.string.history_error_message, state.errorMessage)
+            }
+            reports.isEmpty() -> {
+                historyError.visibility = View.VISIBLE
+                historyError.setText(R.string.history_empty_state)
+            }
+            else -> {
+                historyError.visibility = View.GONE
+            }
+        }
     }
 
     private fun showHideBatteryBanner(subscriptions: List<Subscription>) {
@@ -735,6 +854,7 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
     }
 
     companion object {
+        private const val STATE_SELECTED_NAVIGATION = "state_selected_navigation"
         const val TAG = "NtfyMainActivity"
         const val EXTRA_SUBSCRIPTION_ID = "subscriptionId"
         const val EXTRA_SUBSCRIPTION_BASE_URL = "subscriptionBaseUrl"

--- a/app/src/main/java/io/heckel/ntfy/ui/history/QuakeHistoryAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/history/QuakeHistoryAdapter.kt
@@ -1,0 +1,76 @@
+package io.heckel.ntfy.ui.history
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import io.heckel.ntfy.R
+import io.heckel.ntfy.history.QuakeReport
+
+class QuakeHistoryAdapter : ListAdapter<QuakeReport, QuakeHistoryAdapter.HistoryViewHolder>(DiffCallback) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HistoryViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val view = inflater.inflate(R.layout.item_quake_history, parent, false)
+        return HistoryViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: HistoryViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class HistoryViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val header: TextView = itemView.findViewById(R.id.history_item_header)
+        private val location: TextView = itemView.findViewById(R.id.history_item_location)
+        private val coordinates: TextView = itemView.findViewById(R.id.history_item_coordinates)
+        private val magnitude: TextView = itemView.findViewById(R.id.history_item_magnitude)
+        private val depth: TextView = itemView.findViewById(R.id.history_item_depth)
+        private val potential: TextView = itemView.findViewById(R.id.history_item_potential)
+        private val felt: TextView = itemView.findViewById(R.id.history_item_felt)
+        private val source: TextView = itemView.findViewById(R.id.history_item_source)
+        private val eventId: TextView = itemView.findViewById(R.id.history_item_event_id)
+
+        fun bind(report: QuakeReport) {
+            val context = itemView.context
+            val headerText = report.header
+            header.text = if (headerText.isNotBlank()) {
+                headerText
+            } else {
+                context.getString(R.string.history_item_unknown_time)
+            }
+
+            bindWithLabel(location, R.string.history_item_location, report.location)
+            bindWithLabel(coordinates, R.string.history_item_coordinates, report.coordinates)
+            bindWithLabel(magnitude, R.string.history_item_magnitude, report.magnitude)
+            bindWithLabel(depth, R.string.history_item_depth, report.depth)
+            bindWithLabel(potential, R.string.history_item_potential, report.potential)
+            bindWithLabel(felt, R.string.history_item_felt, report.felt)
+            bindWithLabel(source, R.string.history_item_source, report.source)
+            bindWithLabel(eventId, R.string.history_item_event_id, report.eventId)
+        }
+
+        private fun bindWithLabel(textView: TextView, labelRes: Int, value: String?) {
+            if (!value.isNullOrBlank()) {
+                textView.visibility = View.VISIBLE
+                textView.text = textView.context.getString(labelRes, value)
+            } else {
+                textView.visibility = View.GONE
+            }
+        }
+    }
+
+    companion object DiffCallback : DiffUtil.ItemCallback<QuakeReport>() {
+        override fun areItemsTheSame(oldItem: QuakeReport, newItem: QuakeReport): Boolean {
+            val oldId = oldItem.eventId?.takeIf { it.isNotBlank() }
+            val newId = newItem.eventId?.takeIf { it.isNotBlank() }
+            return when {
+                oldId != null && newId != null -> oldId == newId
+                else -> oldItem.date == newItem.date && oldItem.time == newItem.time && oldItem.location == newItem.location
+            }
+        }
+
+        override fun areContentsTheSame(oldItem: QuakeReport, newItem: QuakeReport): Boolean = oldItem == newItem
+    }
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/history/QuakeHistoryViewModel.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/history/QuakeHistoryViewModel.kt
@@ -1,0 +1,60 @@
+package io.heckel.ntfy.ui.history
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.heckel.ntfy.history.QuakeHistoryRepository
+import io.heckel.ntfy.history.QuakeReport
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class QuakeHistoryViewModel(
+    private val repository: QuakeHistoryRepository = QuakeHistoryRepository()
+) : ViewModel() {
+    private val _reports = MutableLiveData<List<QuakeReport>>(emptyList())
+    val reports: LiveData<List<QuakeReport>> = _reports
+
+    private val _uiState = MutableLiveData(HistoryUiState())
+    val uiState: LiveData<HistoryUiState> = _uiState
+
+    private var hasLoaded = false
+
+    fun loadInitial() {
+        if (hasLoaded) {
+            return
+        }
+        fetchReports()
+    }
+
+    fun refresh() {
+        fetchReports(forceRefresh = true)
+    }
+
+    private fun fetchReports(forceRefresh: Boolean = false) {
+        _uiState.postValue(HistoryUiState(loading = true))
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val result = repository.fetchReports()
+                _reports.postValue(result)
+                _uiState.postValue(HistoryUiState())
+                hasLoaded = true
+            } catch (e: Exception) {
+                _uiState.postValue(
+                    HistoryUiState(
+                        loading = false,
+                        errorMessage = e.message ?: e.javaClass.simpleName
+                    )
+                )
+                if (!forceRefresh) {
+                    hasLoaded = false
+                }
+            }
+        }
+    }
+
+    data class HistoryUiState(
+        val loading: Boolean = false,
+        val errorMessage: String? = null
+    )
+}

--- a/app/src/main/res/color/bottom_navigation_item_tint.xml
+++ b/app/src/main/res/color/bottom_navigation_item_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorPrimary" android:state_checked="true"/>
+    <item android:color="?attr/colorOnSurface" android:state_checked="false"/>
+</selector>

--- a/app/src/main/res/drawable/ic_nav_alerts.xml
+++ b/app/src/main/res/drawable/ic_nav_alerts.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_nav_history.xml
+++ b/app/src/main/res/drawable/ic_nav_history.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:fillType="evenOdd"
+        android:pathData="M6,4h12c1.66,0 3,1.34 3,3v10c0,1.66 -1.34,3 -3,3H6c-1.66,0 -3,-1.34 -3,-3V7c0,-1.66 1.34,-3 3,-3zm0,2c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h12c0.55,0 1,-0.45 1,-1V7c0,-0.55 -0.45,-1 -1,-1H6z"/>
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M8,9h8v1.5H8z"/>
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M8,13h8v1.5H8z"/>
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M8,17h5v1.5H8z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,16 +4,25 @@
                                                    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
                                                    android:layout_height="match_parent">
 
-    <com.google.android.material.card.MaterialCardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:shapeAppearance="?shapeAppearanceLargeComponent"
+    <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/main_alerts_container"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:id="@+id/main_banner_battery"
-            android:visibility="visible"
-    >
+            app:layout_constraintBottom_toTopOf="@+id/bottom_navigation">
+
+        <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:shapeAppearance="?shapeAppearanceLargeComponent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                android:id="@+id/main_banner_battery"
+                android:visibility="visible"
+        >
         <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -79,9 +88,9 @@
                     android:text="@string/main_banner_battery_button_fix_now"
                     tools:layout_editor_absoluteX="269dp" tools:layout_editor_absoluteY="67dp"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
+        </com.google.android.material.card.MaterialCardView>
 
-    <com.google.android.material.card.MaterialCardView
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:shapeAppearance="?shapeAppearanceLargeComponent" app:layout_constraintStart_toStartOf="parent"
@@ -146,14 +155,14 @@
                     android:text="@string/main_banner_websocket_button_enable_now"
                     tools:layout_editor_absoluteX="253dp" tools:layout_editor_absoluteY="131dp"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
+        </com.google.android.material.card.MaterialCardView>
 
-    <com.google.android.material.card.MaterialCardView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:shapeAppearance="?shapeAppearanceLargeComponent" app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" app:layout_constraintTop_toBottomOf="@+id/main_banner_websocket"
-        android:id="@+id/main_banner_websocket_reconnect" android:visibility="visible">
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:shapeAppearance="?shapeAppearanceLargeComponent" app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" app:layout_constraintTop_toBottomOf="@+id/main_banner_websocket"
+            android:id="@+id/main_banner_websocket_reconnect" android:visibility="visible">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
@@ -213,36 +222,36 @@
                 android:text="@string/main_banner_websocket_reconnect_button_enable_now"
                 tools:layout_editor_absoluteX="253dp" tools:layout_editor_absoluteY="131dp"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
+        </com.google.android.material.card.MaterialCardView>
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/main_subscriptions_list_container"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:visibility="visible"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect">
-        <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/main_subscriptions_list"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                android:id="@+id/main_subscriptions_list_container"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clickable="true"
-                android:focusable="true"
-                android:paddingTop="5dp"
-                android:paddingBottom="5dp"
-                android:clipToPadding="false"
-                android:background="?android:attr/selectableItemBackground"
-                app:layoutManager="LinearLayoutManager"/>
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+                android:layout_height="0dp"
+                android:visibility="visible"
+                app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect">
+            <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/main_subscriptions_list"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:paddingTop="5dp"
+                    android:paddingBottom="5dp"
+                    android:clipToPadding="false"
+                    android:background="?android:attr/selectableItemBackground"
+                    app:layoutManager="LinearLayoutManager"/>
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/fab" app:layout_constraintStart_toStartOf="parent"
-            android:id="@+id/main_no_subscriptions" android:visibility="gone">
+        <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toTopOf="@+id/fab" app:layout_constraintStart_toStartOf="parent"
+                android:id="@+id/main_no_subscriptions" android:visibility="gone">
         <ImageView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" app:srcCompat="@drawable/ic_sms_gray_48dp"
@@ -273,18 +282,77 @@
                 android:layout_marginEnd="50dp"
                 android:linksClickable="true"
                 android:autoLink="web"/>
-    </LinearLayout>
+        </LinearLayout>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="24dp"
+                android:contentDescription="@string/main_add_button_description"
+                android:src="@drawable/ic_add_black_24dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                style="@style/FloatingActionButton"
+        />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/history_list_container"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/bottom_navigation">
+        <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/history_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                app:layoutManager="LinearLayoutManager"/>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/history_progress"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="24dp"
-            android:contentDescription="@string/main_add_button_description"
-            android:src="@drawable/ic_add_black_24dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="@+id/history_list_container"
+            app:layout_constraintBottom_toBottomOf="@+id/history_list_container"
+            app:layout_constraintStart_toStartOf="@+id/history_list_container"
+            app:layout_constraintEnd_toEndOf="@+id/history_list_container"/>
+
+    <TextView
+            android:id="@+id/history_error"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingStart="32dp"
+            android:paddingEnd="32dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="@+id/history_list_container"
+            app:layout_constraintBottom_toBottomOf="@+id/history_list_container"
+            app:layout_constraintStart_toStartOf="@+id/history_list_container"
+            app:layout_constraintEnd_toEndOf="@+id/history_list_container"/>
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bottom_navigation"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorSurface"
+            app:itemIconTint="@color/bottom_navigation_item_tint"
+            app:itemTextColor="@color/bottom_navigation_item_tint"
+            app:menu="@menu/menu_bottom_navigation"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            style="@style/FloatingActionButton"
-    />
+            app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_quake_history.xml
+++ b/app/src/main/res/layout/item_quake_history.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="12dp"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardElevation="2dp"
+    app:strokeWidth="0dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/history_item_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            android:textStyle="bold"/>
+
+        <TextView
+            android:id="@+id/history_item_location"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"/>
+
+        <TextView
+            android:id="@+id/history_item_coordinates"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption"/>
+
+        <TextView
+            android:id="@+id/history_item_magnitude"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+            android:textStyle="bold"/>
+
+        <TextView
+            android:id="@+id/history_item_depth"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body2"/>
+
+        <TextView
+            android:id="@+id/history_item_potential"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body2"/>
+
+        <TextView
+            android:id="@+id/history_item_felt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body2"/>
+
+        <TextView
+            android:id="@+id/history_item_source"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption"/>
+
+        <TextView
+            android:id="@+id/history_item_event_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption"/>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/navigation_alerts"
+        android:icon="@drawable/ic_nav_alerts"
+        android:title="@string/main_quake_alerts_title"/>
+    <item
+        android:id="@+id/navigation_history"
+        android:icon="@drawable/ic_nav_history"
+        android:title="@string/main_quake_history_title"/>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
 
     <!-- Main activity: Action bar -->
     <string name="main_action_bar_title">Subscribed topics</string>
+    <string name="main_quake_alerts_title" translatable="false">Quake Alerts</string>
+    <string name="main_quake_history_title" translatable="false">Quake History Reports</string>
     <string name="main_menu_notifications_enabled">Notifications on</string>
     <string name="main_menu_notifications_disabled_forever">Notifications muted</string>
     <string name="main_menu_notifications_disabled_until">Notifications muted until %1$s</string>
@@ -69,6 +71,19 @@
     <string name="main_how_to_link">Detailed instructions available on ntfy.sh, and in the docs.
     </string>
     <string name="main_unified_push_toast">This subscription is managed by %1$s via UnifiedPush</string>
+
+    <!-- Quake history reports -->
+    <string name="history_empty_state">No quake history reports are available right now.</string>
+    <string name="history_error_message">Unable to load quake history reports. %1$s</string>
+    <string name="history_item_unknown_time">Unknown time</string>
+    <string name="history_item_location">Location: %1$s</string>
+    <string name="history_item_coordinates">Coordinates: %1$s</string>
+    <string name="history_item_magnitude">Magnitude: %1$s</string>
+    <string name="history_item_depth">Depth: %1$s</string>
+    <string name="history_item_potential">Potential: %1$s</string>
+    <string name="history_item_felt">Felt reports: %1$s</string>
+    <string name="history_item_source">Source: %1$s</string>
+    <string name="history_item_event_id">Event ID: %1$s</string>
 
     <!-- Main activity: Battery banner -->
     <string name="main_banner_battery_text">Battery optimization should be off for the app to avoid notification delivery issues.</string>


### PR DESCRIPTION
## Summary
- add a bottom navigation bar with Quake Alerts and Quake History Reports entries
- implement a history screen that fetches reports from the remote endpoint and displays them in cards
- add navigation icons, resources, and strings to support the new navigation structure

## Testing
- ./gradlew lintFdroidDebug *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd9b1d288832d9efd6f41eccf05de