### PR TITLE
Add bottom navigation with quake history reports screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,16 @@
             </intent-filter>
         </activity>
 
+        <activity
+                android:name=".ui.QuakeHistoryActivity"
+                android:label="@string/quake_history_title"
+                android:parentActivityName=".ui.MainActivity"
+                android:exported="false">
+            <meta-data
+                    android:name="android.support.PARENT_ACTIVITY"
+                    android:value=".ui.MainActivity"/>
+        </activity>
+
         <!-- Detail activity -->
         <activity
                 android:name=".ui.DetailActivity"

--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.work.*
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import io.heckel.ntfy.BuildConfig
 import io.heckel.ntfy.R
@@ -67,6 +68,7 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
     private lateinit var mainListContainer: SwipeRefreshLayout
     private lateinit var adapter: MainAdapter
     private lateinit var fab: FloatingActionButton
+    private lateinit var bottomNavigation: BottomNavigationView
 
     // Other stuff
     private var actionMode: ActionMode? = null
@@ -86,8 +88,24 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         dispatcher = NotificationDispatcher(this, repository)
         appBaseUrl = getString(R.string.app_base_url)
 
+        // Navigation bar
+        bottomNavigation = findViewById(R.id.bottom_navigation)
+        bottomNavigation.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.menu_alerts -> true
+                R.id.menu_history -> {
+                    startActivity(Intent(this, QuakeHistoryActivity::class.java))
+                    overridePendingTransition(0, 0)
+                    true
+                }
+                else -> false
+            }
+        }
+        bottomNavigation.setOnItemReselectedListener { }
+        bottomNavigation.selectedItemId = R.id.menu_alerts
+
         // Action bar
-        title = getString(R.string.main_action_bar_title)
+        title = getString(R.string.quake_alerts_title)
 
         // Floating action button ("+")
         fab = findViewById(R.id.fab)
@@ -257,6 +275,9 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
 
     override fun onResume() {
         super.onResume()
+        if (::bottomNavigation.isInitialized) {
+            bottomNavigation.selectedItemId = R.id.menu_alerts
+        }
         showHideNotificationMenuItems()
         redrawList()
     }

--- a/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryActivity.kt
@@ -1,0 +1,248 @@
+package io.heckel.ntfy.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.google.android.material.bottomnavigation.BottomNavigationView
+import io.heckel.ntfy.R
+import io.heckel.ntfy.msg.ApiService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+class QuakeHistoryActivity : AppCompatActivity() {
+    private lateinit var bottomNavigation: BottomNavigationView
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var swipeRefreshLayout: SwipeRefreshLayout
+    private lateinit var progressBar: ProgressBar
+    private lateinit var statusText: TextView
+    private lateinit var adapter: QuakeHistoryAdapter
+
+    private val httpClient = OkHttpClient.Builder()
+        .callTimeout(15, TimeUnit.SECONDS)
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(15, TimeUnit.SECONDS)
+        .writeTimeout(15, TimeUnit.SECONDS)
+        .build()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_quake_history)
+
+        title = getString(R.string.quake_history_title)
+
+        bottomNavigation = findViewById(R.id.bottom_navigation)
+        bottomNavigation.selectedItemId = R.id.menu_history
+        bottomNavigation.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.menu_alerts -> {
+                    val intent = Intent(this, MainActivity::class.java)
+                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                    startActivity(intent)
+                    overridePendingTransition(0, 0)
+                    finish()
+                    true
+                }
+                R.id.menu_history -> true
+                else -> false
+            }
+        }
+        bottomNavigation.setOnItemReselectedListener { }
+
+        recyclerView = findViewById(R.id.quake_history_list)
+        swipeRefreshLayout = findViewById(R.id.quake_history_refresh)
+        progressBar = findViewById(R.id.quake_history_progress)
+        statusText = findViewById(R.id.quake_history_status_text)
+
+        adapter = QuakeHistoryAdapter()
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = adapter
+
+        swipeRefreshLayout.setOnRefreshListener { loadReports(showProgress = false) }
+        swipeRefreshLayout.setColorSchemeResources(Colors.refreshProgressIndicator)
+
+        loadReports(showProgress = true)
+    }
+
+    private fun loadReports(showProgress: Boolean) {
+        if (showProgress) {
+            progressBar.isVisible = true
+            statusText.isVisible = false
+            recyclerView.isVisible = false
+        } else {
+            statusText.isVisible = false
+        }
+        lifecycleScope.launch {
+            try {
+                val reports = withContext(Dispatchers.IO) { fetchReports() }
+                adapter.submitReports(reports)
+                recyclerView.isVisible = reports.isNotEmpty()
+                statusText.isVisible = reports.isEmpty()
+                if (reports.isEmpty()) {
+                    statusText.text = getString(R.string.quake_history_empty)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load quake history", e)
+                adapter.submitReports(emptyList())
+                recyclerView.isVisible = false
+                statusText.isVisible = true
+                statusText.text = getString(R.string.quake_history_error_generic)
+            } finally {
+                progressBar.isVisible = false
+                swipeRefreshLayout.isRefreshing = false
+            }
+        }
+    }
+
+    private fun fetchReports(): List<QuakeReport> {
+        val request = Request.Builder()
+            .url(REPORTS_URL)
+            .addHeader("User-Agent", ApiService.USER_AGENT)
+            .addHeader("Accept", "application/json")
+            .build()
+        httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Unexpected response ${response.code}")
+            }
+            val body = response.body?.string()?.trim().orEmpty()
+            if (body.isEmpty()) {
+                return emptyList()
+            }
+            return parseReports(body)
+        }
+    }
+
+    private fun parseReports(json: String): List<QuakeReport> {
+        val parsed = com.google.gson.JsonParser.parseString(json)
+        val reports = mutableListOf<QuakeReport>()
+
+        fun parseArray(array: com.google.gson.JsonArray) {
+            array.forEach { element ->
+                if (element.isJsonObject) {
+                    parseItem(element.asJsonObject)?.let { reports.add(it) }
+                }
+            }
+        }
+
+        fun findArray(obj: com.google.gson.JsonObject): com.google.gson.JsonArray? {
+            val preferredKeys = listOf("data", "laporan", "reports", "gempa", "items", "result")
+            for (key in preferredKeys) {
+                val candidate = obj.get(key) ?: continue
+                when {
+                    candidate.isJsonArray -> return candidate.asJsonArray
+                    candidate.isJsonObject -> {
+                        val nested = findArray(candidate.asJsonObject)
+                        if (nested != null) {
+                            return nested
+                        }
+                    }
+                }
+            }
+            for (entry in obj.entrySet()) {
+                val value = entry.value
+                when {
+                    value.isJsonArray -> return value.asJsonArray
+                    value.isJsonObject -> {
+                        val nested = findArray(value.asJsonObject)
+                        if (nested != null) {
+                            return nested
+                        }
+                    }
+                }
+            }
+            return null
+        }
+
+        when {
+            parsed.isJsonArray -> parseArray(parsed.asJsonArray)
+            parsed.isJsonObject -> {
+                val obj = parsed.asJsonObject
+                val array = findArray(obj)
+                if (array != null) {
+                    parseArray(array)
+                } else {
+                    parseItem(obj)?.let { reports.add(it) }
+                }
+            }
+        }
+
+        return reports
+    }
+
+    private fun parseItem(obj: com.google.gson.JsonObject): QuakeReport? {
+        fun com.google.gson.JsonObject.valueFor(vararg keys: String): String? {
+            for (key in keys) {
+                if (has(key)) {
+                    val element = get(key)
+                    if (element != null && element.isJsonPrimitive) {
+                        val value = element.asString.trim()
+                        if (value.isNotEmpty() && !value.equals("null", ignoreCase = true)) {
+                            return value
+                        }
+                    }
+                }
+            }
+            return null
+        }
+
+        val date = obj.valueFor("tanggal", "date", "day", "tanggal_indo")
+        val time = obj.valueFor("jam", "time", "waktu")
+        val magnitude = obj.valueFor("magnitudo", "magnitude", "mag", "m", "sr")
+        val depth = obj.valueFor("kedalaman", "depth")
+        val potential = obj.valueFor("potensi", "potential", "dirasakan", "felt", "tsunami", "warning")
+        val coordinatesRaw = obj.valueFor("coordinates", "koordinat", "coordinate")
+        val latitude = obj.valueFor("lintang", "latitude", "lat")
+        val longitude = obj.valueFor("bujur", "longitude", "lon", "lng")
+        val coordinates = when {
+            !coordinatesRaw.isNullOrBlank() -> coordinatesRaw
+            !latitude.isNullOrBlank() || !longitude.isNullOrBlank() -> listOfNotNull(latitude, longitude).joinToString(", ")
+            else -> null
+        }
+        val notes = obj.valueFor("keterangan", "note", "ket", "information", "info", "deskripsi", "description", "dampak")
+        val location = obj.valueFor(
+            "wilayah",
+            "lokasi",
+            "location",
+            "area",
+            "place",
+            "region",
+            "title",
+            "judul",
+            "event"
+        ) ?: notes
+
+        val hasContent = listOf(date, time, magnitude, depth, location, potential, coordinates, notes)
+            .any { !it.isNullOrBlank() }
+        if (!hasContent) {
+            return null
+        }
+
+        return QuakeReport(
+            date = date,
+            time = time,
+            magnitude = magnitude,
+            depth = depth,
+            location = location,
+            potential = potential,
+            coordinates = coordinates,
+            notes = notes
+        )
+    }
+
+    companion object {
+        private const val REPORTS_URL = "https://quakealert.bananapixel.my.id/laporan"
+        private const val TAG = "QuakeHistory"
+    }
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryAdapter.kt
@@ -1,0 +1,78 @@
+package io.heckel.ntfy.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import io.heckel.ntfy.R
+
+class QuakeHistoryAdapter : RecyclerView.Adapter<QuakeHistoryAdapter.QuakeHistoryViewHolder>() {
+    private val reports = mutableListOf<QuakeReport>()
+
+    fun submitReports(newReports: List<QuakeReport>) {
+        reports.clear()
+        reports.addAll(newReports)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QuakeHistoryViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_quake_history, parent, false)
+        return QuakeHistoryViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = reports.size
+
+    override fun onBindViewHolder(holder: QuakeHistoryViewHolder, position: Int) {
+        holder.bind(reports[position])
+    }
+
+    class QuakeHistoryViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val locationView: TextView = itemView.findViewById(R.id.quake_history_location)
+        private val dateView: TextView = itemView.findViewById(R.id.quake_history_date)
+        private val detailsView: TextView = itemView.findViewById(R.id.quake_history_details)
+        private val additionalView: TextView = itemView.findViewById(R.id.quake_history_additional)
+
+        fun bind(report: QuakeReport) {
+            val context = itemView.context
+            val location = report.location?.takeIf { it.isNotBlank() }
+                ?: context.getString(R.string.quake_history_unknown_location)
+            locationView.text = location
+
+            val dateParts = listOfNotNull(
+                report.date?.takeIf { it.isNotBlank() },
+                report.time?.takeIf { it.isNotBlank() }
+            )
+            dateView.isVisible = dateParts.isNotEmpty()
+            if (dateParts.isNotEmpty()) {
+                dateView.text = dateParts.joinToString(" • ")
+            }
+
+            val detailParts = mutableListOf<String>()
+            report.magnitude?.takeIf { it.isNotBlank() }?.let {
+                detailParts.add(context.getString(R.string.quake_history_magnitude_format, it))
+            }
+            report.depth?.takeIf { it.isNotBlank() }?.let {
+                detailParts.add(context.getString(R.string.quake_history_depth_format, it))
+            }
+            report.coordinates?.takeIf { it.isNotBlank() }?.let {
+                detailParts.add(context.getString(R.string.quake_history_coordinates_format, it))
+            }
+            detailsView.isVisible = detailParts.isNotEmpty()
+            if (detailParts.isNotEmpty()) {
+                detailsView.text = detailParts.joinToString("   ")
+            }
+
+            val infoParts = mutableListOf<String>()
+            report.potential?.takeIf { it.isNotBlank() }?.let {
+                infoParts.add(context.getString(R.string.quake_history_potential_format, it))
+            }
+            report.notes?.takeIf { it.isNotBlank() }?.let { infoParts.add(it) }
+            additionalView.isVisible = infoParts.isNotEmpty()
+            if (infoParts.isNotEmpty()) {
+                additionalView.text = infoParts.joinToString("\n")
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/QuakeReport.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/QuakeReport.kt
@@ -1,0 +1,12 @@
+package io.heckel.ntfy.ui
+
+data class QuakeReport(
+    val date: String?,
+    val time: String?,
+    val magnitude: String?,
+    val depth: String?,
+    val location: String?,
+    val potential: String?,
+    val coordinates: String?,
+    val notes: String?
+)

--- a/app/src/main/res/drawable/ic_nav_quake_alerts.xml
+++ b/app/src/main/res/drawable/ic_nav_quake_alerts.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7.58,4.08L6.15,2.65C3.99,4.47 2.67,7.16 2.67,10h2c0,-2.39 1.28,-4.49 2.91,-5.92zM16.42,4.08L17.85,2.65C20.01,4.47 21.33,7.16 21.33,10h-2c0,-2.39 -1.28,-4.49 -2.91,-5.92zM18.33,11c0,-3.07 -1.97,-5.64 -4.83,-6.32V4c0,-0.83 -0.67,-1.5 -1.5,-1.5S10.5,3.17 10.5,4v0.68C7.64,5.36 5.67,7.92 5.67,11v5L4,17.67V18.5h16v-0.83L18.33,16v-5zM12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.9,2 2,2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_nav_quake_history.xml
+++ b/app/src/main/res/drawable/ic_nav_quake_history.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,3H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2zM19,19H5V5h14v14zM17,7H7v2h10V7zM17,11H7v2h10v-2zM13,15H7v2h6v-2z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -221,7 +221,7 @@
             android:layout_height="0dp"
             android:visibility="visible"
             app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/bottom_navigation"
             app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect">
         <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/main_subscriptions_list"
@@ -275,6 +275,16 @@
                 android:autoLink="web"/>
     </LinearLayout>
 
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bottom_navigation"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorSurface"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:menu="@menu/menu_bottom_navigation" />
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab"
             android:layout_width="wrap_content"
@@ -282,7 +292,7 @@
             android:layout_margin="24dp"
             android:contentDescription="@string/main_add_button_description"
             android:src="@drawable/ic_add_black_24dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/bottom_navigation"
             app:layout_constraintEnd_toEndOf="parent"
             style="@style/FloatingActionButton"
     />

--- a/app/src/main/res/layout/activity_quake_history.xml
+++ b/app/src/main/res/layout/activity_quake_history.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.QuakeHistoryActivity">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/quake_history_refresh"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_navigation">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/quake_history_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            tools:listitem="@layout/item_quake_history" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <ProgressBar
+        android:id="@+id/quake_history_progress"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="@id/quake_history_refresh"
+        app:layout_constraintBottom_toBottomOf="@id/quake_history_refresh"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/quake_history_status_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="24dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="@id/quake_history_refresh"
+        app:layout_constraintBottom_toBottomOf="@id/quake_history_refresh"
+        app:layout_constraintStart_toStartOf="@id/quake_history_refresh"
+        app:layout_constraintEnd_toEndOf="@id/quake_history_refresh"
+        tools:text="Loading quake history" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_navigation"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:menu="@menu/menu_bottom_navigation" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_quake_history.xml
+++ b/app/src/main/res/layout/item_quake_history.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="12dp"
+    app:cardElevation="2dp"
+    app:strokeColor="@color/gray_400"
+    app:strokeWidth="1dp"
+    app:shapeAppearance="?shapeAppearanceMediumComponent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/quake_history_location"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            android:textColor="?attr/colorOnSurface"
+            android:textStyle="bold"
+            tools:text="Jakarta, Indonesia" />
+
+        <TextView
+            android:id="@+id/quake_history_date"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+            tools:text="21 Sep 2025 • 14:32:11 WIB" />
+
+        <TextView
+            android:id="@+id/quake_history_details"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+            tools:text="Magnitude: 5.2   Depth: 10 km   Coordinates: -6.2, 107.4" />
+
+        <TextView
+            android:id="@+id/quake_history_additional"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+            tools:text="Potential: Tidak berpotensi tsunami
+Dirasakan: II-III MMI" />
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_alerts"
+        android:icon="@drawable/ic_nav_quake_alerts"
+        android:title="@string/nav_quake_alerts" />
+    <item
+        android:id="@+id/menu_history"
+        android:icon="@drawable/ic_nav_quake_history"
+        android:title="@string/nav_quake_history" />
+</menu>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -19,6 +19,10 @@
 \n%2$s</string>
     <string name="refresh_message_error_one">Tidak dapat memuat ulang langganan: %1$s</string>
     <string name="main_action_bar_title">Topik berlangganan</string>
+    <string name="quake_alerts_title">Peringatan Gempa</string>
+    <string name="quake_history_title">Laporan Riwayat Gempa</string>
+    <string name="nav_quake_alerts">Peringatan Gempa</string>
+    <string name="nav_quake_history">Laporan Riwayat Gempa</string>
     <string name="main_menu_notifications_enabled">Notifikasi menyala</string>
     <string name="main_menu_notifications_disabled_forever">Notifikasi dibisukan</string>
     <string name="main_menu_notifications_disabled_until">Notifikasi dibisukan sampai %1$s</string>
@@ -158,6 +162,14 @@
     <string name="settings_general_header">Umum</string>
     <string name="settings_general_default_base_url_title">Server bawaan</string>
     <string name="settings_general_default_base_url_message">Masukkan URL akar server Anda untuk menggunakan server Anda sendiri untuk bawaan ketika berlangganan ke topik baru dan/atau membagikan ke topik.</string>
+
+    <string name="quake_history_error_generic">Tidak dapat memuat laporan gempa. Coba lagi nanti.</string>
+    <string name="quake_history_empty">Belum ada laporan riwayat gempa.</string>
+    <string name="quake_history_magnitude_format">Magnitudo: %1$s</string>
+    <string name="quake_history_depth_format">Kedalaman: %1$s</string>
+    <string name="quake_history_coordinates_format">Koordinat: %1$s</string>
+    <string name="quake_history_potential_format">Potensi: %1$s</string>
+    <string name="quake_history_unknown_location">Lokasi tidak diketahui</string>
     <string name="settings_general_default_base_url_default_summary">%1$s (bawaan)</string>
     <string name="settings_general_users_title">Kelola pengguna</string>
     <string name="settings_general_users_summary">Tambahkan/hapus pengguna untuk topik yang dilindungi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,10 @@
 
     <!-- Main activity: Action bar -->
     <string name="main_action_bar_title">Subscribed topics</string>
+    <string name="quake_alerts_title">Quake Alerts</string>
+    <string name="quake_history_title">Quake History Reports</string>
+    <string name="nav_quake_alerts">Quake Alerts</string>
+    <string name="nav_quake_history">Quake History Reports</string>
     <string name="main_menu_notifications_enabled">Notifications on</string>
     <string name="main_menu_notifications_disabled_forever">Notifications muted</string>
     <string name="main_menu_notifications_disabled_until">Notifications muted until %1$s</string>
@@ -158,6 +162,15 @@
     <string name="detail_item_saved_successfully">Saved as \"%1$s\" in the \"Downloads\" folder</string>
     <string name="detail_item_cannot_download">Cannot open or download attachment. The link expired and no local file could be found.</string>
     <string name="detail_item_cannot_open">Cannot open attachment: %1$s</string>
+
+    <!-- Quake history -->
+    <string name="quake_history_error_generic">Unable to load quake history. Please try again later.</string>
+    <string name="quake_history_empty">No quake history reports are available right now.</string>
+    <string name="quake_history_magnitude_format">Magnitude: %1$s</string>
+    <string name="quake_history_depth_format">Depth: %1$s</string>
+    <string name="quake_history_coordinates_format">Coordinates: %1$s</string>
+    <string name="quake_history_potential_format">Potential: %1$s</string>
+    <string name="quake_history_unknown_location">Unknown location</string>
     <string name="detail_item_cannot_open_not_found">Cannot open attachment: The file may have been deleted, or no installed app can open the file.</string>
     <string name="detail_item_cannot_open_url">Cannot open URL: %1$s</string>
     <string name="detail_item_cannot_open_apk">Apps cannot be installed anymore. Download via browser instead. See issue #531 for details.</string>


### PR DESCRIPTION
## Summary
- add a bottom navigation bar that exposes the Quake Alerts home view and a new Quake History Reports destination
- implement the Quake History screen to load and render reports from quakealert.bananapixel.my.id in a recycler view with pull-to-refresh feedback
- update resources, strings, icons and the manifest to support the new navigation structure and localized labels
- fix the quake history list item layout by declaring the tools namespace so it compiles cleanly

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfef056260832dba9cdac1a9e01c59