### PR TITLE
Fix material navigation active indicator build failure

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
     // Material design
-    implementation "com.google.android.material:material:1.9.0"
+    implementation "com.google.android.material:material:1.12.0"
 
     // LiveData
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.6.1"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -54,7 +54,6 @@
     </style>
 
     <style name="Widget.Quake.BottomNav.ActiveIndicator" parent="@style/Widget.MaterialComponents.NavigationBar.ActiveIndicator">
-        <item name="android:width">wrap_content</item>
         <item name="android:height">36dp</item>
         <item name="android:insetLeft">12dp</item>
         <item name="android:insetRight">12dp</item>


### PR DESCRIPTION
## Summary
- update Material Components dependency to 1.12.0 to provide the NavigationBar ActiveIndicator style
- rely on the parent style's default width for the bottom navigation active indicator to keep resource attributes valid

## Testing
- ./gradlew assemblePlayDebug *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d002f1d02c832dac12685b625c4249