### PR TITLE
Fix bottom nav active indicator style parent

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -53,7 +53,7 @@
         <item name="labelVisibilityMode">labeled</item>
     </style>
 
-    <style name="Widget.Quake.BottomNav.ActiveIndicator" parent="@style/Widget.MaterialComponents.NavigationBar.ActiveIndicator">
+    <style name="Widget.Quake.BottomNav.ActiveIndicator">
         <item name="android:height">36dp</item>
         <item name="android:insetLeft">12dp</item>
         <item name="android:insetRight">12dp</item>


### PR DESCRIPTION
## Summary
- remove the dependency on the missing MaterialComponents NavigationBar active indicator style by making the custom style standalone

## Testing
- `./gradlew assemblePlayDebug` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d00bc83bd4832daa3f980916a2c29f