### PR TITLE
Define legacy bottom navigation style alias

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -53,6 +53,9 @@
         <item name="labelVisibilityMode">labeled</item>
     </style>
 
+    <!-- Temporary alias to maintain compatibility with legacy references -->
+    <style name="Widget.Quake.BottomNav" parent="@style/Widget.Quake.BottomNavigationView" />
+
     <style name="Widget.Quake.BottomNav.ActiveIndicator">
         <item name="android:height">36dp</item>
         <item name="android:insetLeft">12dp</item>


### PR DESCRIPTION
## Summary
- add a Widget.Quake.BottomNav style alias so legacy resource references resolve to the new bottom navigation style

## Testing
- ./gradlew :app:processPlayDebugResources *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d00d82f3d4832d8a832af2edcf8e82