### PR TITLE
Disable bottom navigation item shifting

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -301,6 +301,7 @@
                 android:paddingStart="12dp"
                 android:paddingEnd="12dp"
                 style="@style/Widget.Quake.BottomNavigationView"
+                app:itemHorizontalTranslationEnabled="false"
                 app:menu="@menu/menu_bottom_navigation" />
 
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/activity_quake_history.xml
+++ b/app/src/main/res/layout/activity_quake_history.xml
@@ -78,6 +78,7 @@
             android:paddingStart="12dp"
             android:paddingEnd="12dp"
             style="@style/Widget.Quake.BottomNavigationView"
+            app:itemHorizontalTranslationEnabled="false"
             app:menu="@menu/menu_bottom_navigation" />
 
     </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- disable horizontal translation animation on the bottom navigation bar in the main and history screens to prevent the items from wobbling when tapped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0254fb924832d80c57db5022d0131